### PR TITLE
feat: 深度扩充文字与图层动画预设库至 230 种并重构预设面板 UI

### DIFF
--- a/src/app/GUI/textanimpresetpanel.cpp
+++ b/src/app/GUI/textanimpresetpanel.cpp
@@ -27,6 +27,10 @@
 #include "layeranimpresets.h"
 #include "Boxes/textbox.h"
 #include "Boxes/rectangle.h"
+#include "Animators/transformanimator.h"
+#include "Animators/qpointfanimator.h"
+#include "Animators/qrealanimator.h"
+#include "Animators/texteffectcollection.h"
 
 #include "Private/document.h"
 #include "canvas.h"
@@ -38,6 +42,8 @@
 #include <QGridLayout>
 #include <QHBoxLayout>
 #include <QLabel>
+#include <QLineEdit>
+#include <QButtonGroup>
 #include <QPainter>
 #include <QPaintEvent>
 #include <QPointer>
@@ -224,9 +230,10 @@ void TextAnimPreview::paintEvent(QPaintEvent* const e)
     QPainter p(this);
     p.setRenderHint(QPainter::Antialiasing);
     // rounded dark frame; content is clipped to it
+    const int rad = ThemeSupport::borderRadius();
     QPainterPath frame;
-    frame.addRoundedRect(rect().adjusted(0, 0, -1, -1), 8, 8);
-    p.fillPath(frame, QColor(12, 12, 14));
+    frame.addRoundedRect(rect().adjusted(0, 0, -1, -1), rad, rad);
+    p.fillPath(frame, ThemeSupport::getThemeBaseDarkerColor());
     p.save();
     p.setClipPath(frame);
     if (!mFrames.isEmpty()) {
@@ -256,50 +263,102 @@ TextAnimTile::TextAnimTile(const TextAnimPreset* const textPreset,
     , mLayerPreset(layerPreset)
 {
     const auto lay = new QVBoxLayout(this);
-    lay->setContentsMargins(4, 4, 4, 4);
-    lay->setSpacing(2);
+    lay->setContentsMargins(5, 5, 5, 5);
+    lay->setSpacing(3);
 
-    // square preview area (size driven by the panel zoom slider)
+    // 1. Clean animated preview thumbnail
     mPreviewArea = new TextAnimPreview(this);
-    mPreviewArea->setFixedSize(150, 150);
+    mPreviewArea->setFixedSize(130, 130);
     lay->addWidget(mPreviewArea, 0, Qt::AlignHCenter);
 
+    // 2. Preset Name Label (bold, clean)
     mNameLabel = new QLabel(this);
     QFont nf = mNameLabel->font();
     nf.setPixelSize(11);
+    nf.setBold(true);
     mNameLabel->setFont(nf);
     mNameLabel->setAlignment(Qt::AlignCenter);
     mNameLabel->setText(mTextPreset ? mTextPreset->name :
                           mLayerPreset ? mLayerPreset->name : QString());
+    mNameLabel->setStyleSheet(QStringLiteral("color: %1;")
+                              .arg(palette().color(QPalette::WindowText).name()));
     lay->addWidget(mNameLabel);
-    lay->addStretch(1);
 
-    // small square apply buttons overlaid on the preview, centered
-    // near its bottom edge: in / all / out (loops get one apply)
+    // 3. Subtitle / Tag Pill Label
+    mTagLabel = new QLabel(this);
+    QFont tf = mTagLabel->font();
+    tf.setPixelSize(10);
+    mTagLabel->setFont(tf);
+    mTagLabel->setAlignment(Qt::AlignCenter);
+    mTagLabel->setStyleSheet(QStringLiteral("color: %1;")
+                             .arg(ThemeSupport::getThemeColorTextDisabled().name()));
+    QString subText;
+    if (mTextPreset) {
+        const QString durStr = QString::number(mTextPreset->duration, 'f', 1) + QLatin1String("s");
+        if (mTextPreset->category == 2) {
+            subText = QString::fromUtf8("循环 · ") + durStr;
+        } else {
+            const QString fStr = (mTextPreset->fragment == 0) ? QString::fromUtf8("逐字") :
+                                 (mTextPreset->fragment == 1) ? QString::fromUtf8("逐词") : QString::fromUtf8("逐行");
+            subText = fStr + QString::fromUtf8(" · ") + durStr;
+        }
+    } else if (mLayerPreset) {
+        const QString durStr = QString::number(mLayerPreset->duration, 'f', 1) + QLatin1String("s");
+        if (mLayerPreset->category == 2) {
+            subText = QString::fromUtf8("循环 · ") + durStr;
+        } else {
+            subText = (mLayerPreset->tag == QLatin1String("3d") ? QString::fromUtf8("3D空间 · ") : QString::fromUtf8("图层 · ")) + durStr;
+        }
+    }
+    mTagLabel->setText(subText);
+    lay->addWidget(mTagLabel);
+
+    // 4. Action Buttons Container (Never obscuring the preview!)
+    const auto btnContainer = new QWidget(this);
+    const auto btnLay = new QHBoxLayout(btnContainer);
+    btnLay->setContentsMargins(0, 0, 0, 0);
+    btnLay->setSpacing(3);
+
     const auto addBtn = [&](const QString& label, const int dir) {
-        auto btn = new QPushButton(label, mPreviewArea);
+        auto btn = new QPushButton(label, btnContainer);
         QFont bf = btn->font();
-        bf.setPixelSize(11);
+        bf.setPixelSize(10);
         bf.setBold(true);
         btn->setFont(bf);
-        btn->setFixedSize(40, 26);
+        btn->setFixedHeight(22);
         btn->setCursor(Qt::PointingHandCursor);
-        // nearly opaque pill so the animated content behind does
-        // not wash the label out (user screens run 144dpi)
-        btn->setStyleSheet(
-                    "QPushButton { background: rgba(16,16,20,240);"
-                    " color: #f0f0f0; border: 1px solid #71717a;"
-                    " border-radius: 4px; padding: 0px; }"
-                    "QPushButton:hover { background: rgba(60,90,150,240); }");
+        const QColor btnBg = ThemeSupport::getThemeButtonBaseColor(240);
+        const QColor btnBorder = ThemeSupport::getThemeButtonBorderColor(180);
+        const QColor btnHoverBg = ThemeSupport::getThemeHighlightColor();
+        const int rad = ThemeSupport::borderRadius() > 3 ? 3 : ThemeSupport::borderRadius();
+        btn->setStyleSheet(QStringLiteral(
+            "QPushButton { background: %1; color: %2; border: 1px solid %3; border-radius: %4px; padding: 0px 4px; font-weight: bold; }"
+            "QPushButton:hover { background: %5; border-color: %5; color: #ffffff; }"
+        ).arg(btnBg.name(QColor::HexArgb),
+              palette().color(QPalette::WindowText).name(),
+              btnBorder.name(QColor::HexArgb),
+              QString::number(rad),
+              btnHoverBg.name()));
+        if (label == QString::fromUtf8("入")) {
+            btn->setToolTip(QString::fromUtf8("应用为入场动画（在图层入点生效）"));
+        } else if (label == QString::fromUtf8("全")) {
+            btn->setToolTip(QString::fromUtf8("同时应用入场与出场完整动画"));
+        } else if (label == QString::fromUtf8("出")) {
+            btn->setToolTip(QString::fromUtf8("应用为出场动画（在图层出点生效）"));
+        } else {
+            btn->setToolTip(QString::fromUtf8("应用循环动画（持续运行）"));
+        }
         mApplyButtons << btn;
+        btnLay->addWidget(btn);
         connect(btn, &QPushButton::clicked, this, [this, dir]() {
             emit applyRequested(this, dir);
         });
     };
+
     const bool isLoop = mTextPreset ? mTextPreset->category == 2 :
                         mLayerPreset ? mLayerPreset->category == 2 : false;
     if (isLoop) {
-        addBtn(QString::fromUtf8("应用"), 0);
+        addBtn(QString::fromUtf8("应用循环"), 0);
     } else {
         const bool hasIn = !mLayerPreset || mLayerPreset->gen;
         const bool hasOut = mTextPreset ? mTextPreset->supportsOut :
@@ -310,11 +369,69 @@ TextAnimTile::TextAnimTile(const TextAnimPreset* const textPreset,
         if (hasAll) { addBtn(QString::fromUtf8("全"), 2); }
         if (hasOut) { addBtn(QString::fromUtf8("出"), 1); }
     }
+    lay->addWidget(btnContainer);
 
-    // clicking the preview or the name selects the preset for the
-    // big preview
+    const QString name = mTextPreset ? mTextPreset->name : (mLayerPreset ? mLayerPreset->name : QString());
+    const QString id = mTextPreset ? mTextPreset->id : (mLayerPreset ? mLayerPreset->id : QString());
+    const QString desc = mTextPreset ? mTextPreset->desc : (mLayerPreset ? mLayerPreset->desc : QString());
+    const qreal dur = mTextPreset ? mTextPreset->duration : (mLayerPreset ? mLayerPreset->duration : 1.0);
+    const QString catStr = mTextPreset ? (mTextPreset->category == 2 ? QString::fromUtf8("文字循环") :
+                                         (mTextPreset->fragment == 0 ? QString::fromUtf8("逐字动画") :
+                                         (mTextPreset->fragment == 1 ? QString::fromUtf8("逐词动画") : QString::fromUtf8("逐行动画"))))
+                                       : (mLayerPreset->category == 2 ? QString::fromUtf8("图层循环") : QString::fromUtf8("图层入出场"));
+
+    const QString tip = QStringLiteral(
+                "<div style='font-family:sans-serif; min-width:170px;'>"
+                "<b style='font-size:12px; color:#60a5fa;'>%1</b> <span style='color:#9ca3af;'>[%2]</span><br/>"
+                "<span style='color:#d1d5db; font-size:11px;'>类别：%3 · 时长：%4s</span>"
+                "<p style='color:#e5e7eb; font-size:11px; margin-top:4px; line-height:1.3;'>%5</p>"
+                "</div>")
+            .arg(name, id, catStr, QString::number(dur, 'f', 1), desc);
+    setToolTip(tip);
+
+    // clicking preview, name, or tag selects the preset for details
     mPreviewArea->installEventFilter(this);
     mNameLabel->installEventFilter(this);
+    mTagLabel->installEventFilter(this);
+}
+
+bool TextAnimTile::matches(const QString& query, const QString& filterTag) const
+{
+    if (filterTag != QLatin1String("all")) {
+        if (filterTag == QLatin1String("sharp")) {
+            if (!mTextPreset || mTextPreset->tag != QLatin1String("sharp")) return false;
+        } else if (filterTag == QLatin1String("smooth")) {
+            if (!mTextPreset || mTextPreset->tag != QLatin1String("smooth")) return false;
+        } else if (filterTag == QLatin1String("prop")) {
+            if (!mTextPreset || mTextPreset->tag != QLatin1String("prop")) return false;
+        } else if (filterTag == QLatin1String("3d")) {
+            const bool textMatch = mTextPreset && mTextPreset->tag == QLatin1String("3d");
+            const bool layerMatch = mLayerPreset && (mLayerPreset->tag == QLatin1String("3d") || mLayerPreset->id.contains(QLatin1String("3d")));
+            if (!textMatch && !layerMatch) return false;
+        } else if (filterTag == QLatin1String("tech")) {
+            if (!mTextPreset || mTextPreset->tag != QLatin1String("tech")) return false;
+        } else if (filterTag == QLatin1String("layer")) {
+            if (!mLayerPreset) return false;
+        } else if (filterTag == QLatin1String("loop")) {
+            const bool isLoop = (mTextPreset && (mTextPreset->category == 2 || mTextPreset->tag == QLatin1String("loop"))) ||
+                                (mLayerPreset && mLayerPreset->category == 2);
+            if (!isLoop) return false;
+        }
+    }
+
+    if (!query.isEmpty()) {
+        const QString name = mTextPreset ? mTextPreset->name : (mLayerPreset ? mLayerPreset->name : QString());
+        const QString id = mTextPreset ? mTextPreset->id : (mLayerPreset ? mLayerPreset->id : QString());
+        const QString desc = mTextPreset ? mTextPreset->desc : (mLayerPreset ? mLayerPreset->desc : QString());
+
+        if (!name.contains(query, Qt::CaseInsensitive) &&
+            !id.contains(query, Qt::CaseInsensitive) &&
+            !desc.contains(query, Qt::CaseInsensitive)) {
+            return false;
+        }
+    }
+
+    return true;
 }
 
 bool TextAnimTile::eventFilter(QObject* const obj, QEvent* const e)
@@ -327,9 +444,9 @@ bool TextAnimTile::eventFilter(QObject* const obj, QEvent* const e)
 
 QSize TextAnimTile::sizeHint() const
 {
-    if (!mPreviewArea) { return QSize(180, 230); }
-    return QSize(mPreviewArea->width() + 8,
-                 mPreviewArea->height() + 30);
+    const int w = mPreviewArea ? mPreviewArea->width() + 10 : 140;
+    const int h = mPreviewArea ? mPreviewArea->height() + 72 : 202;
+    return QSize(w, h);
 }
 
 void TextAnimTile::paintEvent(QPaintEvent* const e)
@@ -337,18 +454,27 @@ void TextAnimTile::paintEvent(QPaintEvent* const e)
     Q_UNUSED(e)
     QPainter p(this);
     p.setRenderHint(QPainter::Antialiasing);
-    if (!mPreviewArea) { return; }
-    // selection highlight / hover hint around the preview frame
-    QPainterPath frame;
-    frame.addRoundedRect(QRectF(mPreviewArea->geometry())
-                         .adjusted(0.5, 0.5, -0.5, -0.5), 8, 8);
-    QColor border(70, 70, 76);
-    if (mHover) { border = QColor(110, 110, 120); }
-    if (mChecked) { border = ThemeSupport::getThemeColorBlue(); }
-    QPen pen(border, mChecked ? 2.0 : 1.2);
-    p.setPen(pen);
+
+    const int rad = ThemeSupport::borderRadius();
+    const QRectF cardRect = QRectF(rect()).adjusted(1.0, 1.0, -1.0, -1.0);
+    QPainterPath cardPath;
+    cardPath.addRoundedRect(cardRect, rad, rad);
+
+    // Morandi card background
+    p.fillPath(cardPath, ThemeSupport::getThemeBaseDarkerColor(150));
+
+    // Morandi card border with state styling
+    QColor border = ThemeSupport::getThemeButtonBorderColor(100);
+    qreal penWidth = 1.0;
+    if (mChecked) {
+        border = ThemeSupport::getThemeHighlightColor();
+        penWidth = 2.0;
+    } else if (mHover) {
+        border = ThemeSupport::getThemeButtonHoverColor();
+    }
+    p.setPen(QPen(border, penWidth));
     p.setBrush(Qt::NoBrush);
-    p.drawPath(frame);
+    p.drawPath(cardPath);
 }
 
 void TextAnimTile::enterEvent(QEvent* const e)
@@ -365,37 +491,12 @@ void TextAnimTile::leaveEvent(QEvent* const e)
     update();
 }
 
-void TextAnimTile::resizeEvent(QResizeEvent* const e)
-{
-    QWidget::resizeEvent(e);
-    repositionButtons();
-}
-
-void TextAnimTile::repositionButtons()
-{
-    if (mApplyButtons.isEmpty() || !mPreviewArea) { return; }
-    const int btnW = 40;
-    const int btnH = 26;
-    const int gap = 4;
-    const int n = mApplyButtons.count();
-    const int totalW = n*btnW + (n - 1)*gap;
-    // the buttons are children of the preview area: coordinates
-    // are relative to IT, not to the tile
-    const int x0 = (mPreviewArea->width() - totalW)/2;
-    const int y = mPreviewArea->height() - btnH - 5;
-    for (int i = 0; i < n; i++) {
-        mApplyButtons.at(i)->setGeometry(
-                    x0 + i*(btnW + gap), y, btnW, btnH);
-    }
-    for (const auto btn : mApplyButtons) { btn->raise(); }
-}
-
 void TextAnimTile::setPreviewSize(const int size)
 {
     if (mPreviewArea) {
         mPreviewArea->setFixedSize(size, size);
     }
-    repositionButtons();
+    updateGeometry();
 }
 
 void TextAnimTile::setFrames(const QList<QImage>& frames)
@@ -426,67 +527,226 @@ TextAnimPresetPanel::TextAnimPresetPanel(Document& doc,
     , mDocument(doc)
 {
     setMinimumSize(360, 440);
-    // opaque panel background (no see-through)
     setAutoFillBackground(true);
     setPalette(ThemeSupport::getDarkPalette());
 
     const auto rootLayout = new QVBoxLayout(this);
     rootLayout->setContentsMargins(6, 6, 6, 6);
-    rootLayout->setSpacing(4);
+    rootLayout->setSpacing(6);
 
-    // collapsible preset sections
+    // 1. Search Bar
+    mSearchEdit = new QLineEdit(this);
+    mSearchEdit->setPlaceholderText(QString::fromUtf8("搜索预设（名称、拼音、效果描述）..."));
+    mSearchEdit->setClearButtonEnabled(true);
+    mSearchEdit->setFixedHeight(28);
+    mSearchEdit->setStyleSheet(QStringLiteral(
+        "QLineEdit {"
+        "  background: %1;"
+        "  border: 1px solid %2;"
+        "  border-radius: %3px;"
+        "  padding: 0 8px;"
+        "  color: %4;"
+        "  selection-background-color: %5;"
+        "}"
+        "QLineEdit:focus {"
+        "  border-color: %5;"
+        "}"
+    ).arg(ThemeSupport::getThemeBaseDarkColor().name(),
+          ThemeSupport::getThemeButtonBorderColor().name(),
+          QString::number(ThemeSupport::borderRadius() > 5 ? 5 : ThemeSupport::borderRadius()),
+          palette().color(QPalette::WindowText).name(),
+          ThemeSupport::getThemeHighlightColor().name()));
+    rootLayout->addWidget(mSearchEdit);
+
+    // 2. Category Navigation Tab Bar (with pill styling & counts)
+    const auto catScroll = new QScrollArea(this);
+    catScroll->setWidgetResizable(true);
+    catScroll->setFixedHeight(32);
+    catScroll->setFrameShape(QFrame::NoFrame);
+    catScroll->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+    catScroll->setHorizontalScrollBarPolicy(Qt::ScrollBarAsNeeded);
+    catScroll->setAutoFillBackground(false);
+    catScroll->viewport()->setAutoFillBackground(false);
+
+    const auto catHost = new QWidget(catScroll);
+    const auto catLayout = new QHBoxLayout(catHost);
+    catLayout->setContentsMargins(0, 1, 0, 1);
+    catLayout->setSpacing(5);
+
+    mCategoryGroup = new QButtonGroup(this);
+    mCategoryGroup->setExclusive(true);
+
+    const struct FilterBtnDef {
+        QString label;
+        QString tag;
+    } filterDefs[] = {
+        { QString::fromUtf8("全部"), QStringLiteral("all") },
+        { QString::fromUtf8("锐利动力"), QStringLiteral("sharp") },
+        { QString::fromUtf8("丝滑流体"), QStringLiteral("smooth") },
+        { QString::fromUtf8("属性通道"), QStringLiteral("prop") },
+        { QString::fromUtf8("3D空间"), QStringLiteral("3d") },
+        { QString::fromUtf8("极客代码"), QStringLiteral("tech") },
+        { QString::fromUtf8("图层动效"), QStringLiteral("layer") },
+        { QString::fromUtf8("持续循环"), QStringLiteral("loop") }
+    };
+
+    const QString pillStyle = QStringLiteral(
+        "QPushButton {"
+        "  background: %1;"
+        "  color: %2;"
+        "  border: 1px solid %3;"
+        "  border-radius: 11px;"
+        "  padding: 2px 10px;"
+        "  font-size: 11px;"
+        "  font-weight: 500;"
+        "}"
+        "QPushButton:hover {"
+        "  background: %4;"
+        "  color: %5;"
+        "  border-color: %6;"
+        "}"
+        "QPushButton:checked {"
+        "  background: %6;"
+        "  border-color: %6;"
+        "  color: #ffffff;"
+        "  font-weight: bold;"
+        "}"
+    ).arg(ThemeSupport::getThemeButtonBaseColor().name(),
+          ThemeSupport::getThemeColorTextDisabled().name(),
+          ThemeSupport::getThemeButtonBorderColor().name(),
+          ThemeSupport::getThemeButtonHoverColor().name(),
+          palette().color(QPalette::WindowText).name(),
+          ThemeSupport::getThemeHighlightColor().name());
+
+    for (const auto& def : filterDefs) {
+        auto btn = new QPushButton(def.label, catHost);
+        btn->setCheckable(true);
+        btn->setCursor(Qt::PointingHandCursor);
+        btn->setStyleSheet(pillStyle);
+        btn->setProperty("filterTag", def.tag);
+        btn->setProperty("baseLabel", def.label);
+        if (def.tag == QLatin1String("all")) {
+            btn->setChecked(true);
+        }
+        mCategoryGroup->addButton(btn);
+        catLayout->addWidget(btn);
+    }
+    catLayout->addStretch(1);
+    catScroll->setWidget(catHost);
+    rootLayout->addWidget(catScroll);
+
+    connect(mSearchEdit, &QLineEdit::textChanged, this, [this]() {
+        filterPresets();
+    });
+    connect(mCategoryGroup, static_cast<void(QButtonGroup::*)(QAbstractButton*)>(&QButtonGroup::buttonClicked),
+            this, [this](QAbstractButton* btn) {
+        if (btn) {
+            mActiveFilterTag = btn->property("filterTag").toString();
+            filterPresets();
+        }
+    });
+
+    // 3. Preset Cards Gallery Flow Layout
     mScroll = new QScrollArea(this);
     mScroll->setWidgetResizable(true);
     mScroll->setFrameShape(QFrame::NoFrame);
     mScroll->setAutoFillBackground(true);
     mScroll->viewport()->setAutoFillBackground(true);
+
     mScrollHost = new QWidget(mScroll);
     mScrollHost->setAutoFillBackground(true);
-    const auto hostLayout = new QVBoxLayout(mScrollHost);
-    hostLayout->setContentsMargins(0, 0, 0, 0);
-    hostLayout->setSpacing(4);
+    mFlow = new FlowLayout(mScrollHost);
+    mFlow->setContentsMargins(4, 4, 4, 4);
+    mFlow->setSpacing(8);
 
-    const auto makeSection = [&](Section& section,
-                                 const QString& title) {
-        section.header = new QPushButton(
-                    QString::fromUtf8("▸ ") + title, this);
-        section.header->setCheckable(false);
-        section.header->setFlat(true);
-        QFont hf = section.header->font();
-        hf.setPixelSize(13);
-        hf.setBold(true);
-        section.header->setFont(hf);
-        section.header->setCursor(Qt::PointingHandCursor);
-        hostLayout->addWidget(section.header);
-
-        section.body = new QWidget(mScrollHost);
-        section.flow = new FlowLayout(section.body);
-        hostLayout->addWidget(section.body);
-
-        connect(section.header, &QPushButton::clicked,
-                this, [this, &section, title]() {
-            section.expanded = !section.expanded;
-            section.header->setText(QString::fromUtf8(
-                        section.expanded ? "▾ " : "▸ ") + title);
-            section.body->setVisible(section.expanded);
-            if (section.expanded && !section.built) {
-                buildSection(section,
-                             &section == &mTextSection ? 0 :
-                             &section == &mImageSection ? 1 : 2);
-            }
-        });
-    };
-    makeSection(mTextSection, QString::fromUtf8("文字动画"));
-    makeSection(mImageSection, QString::fromUtf8("图像动画"));
-    makeSection(mLoopSection, QString::fromUtf8("循环动画"));
-    hostLayout->addStretch(1);
     mScroll->setWidget(mScrollHost);
     rootLayout->addWidget(mScroll, 1);
 
-    // first section open by default
-    mTextSection.expanded = true;
-    mTextSection.header->setText(
-                QString::fromUtf8("▾ 文字动画"));
+    // 4. Structured Footer Controls Toolbar
+    const auto footerWidget = new QWidget(this);
+    footerWidget->setAutoFillBackground(true);
+    const auto footerLayout = new QVBoxLayout(footerWidget);
+    footerLayout->setContentsMargins(2, 2, 2, 2);
+    footerLayout->setSpacing(4);
+
+    // Row 1: Duration & Zoom Sliders
+    const auto ctrlRow = new QHBoxLayout();
+    ctrlRow->setSpacing(6);
+    ctrlRow->setContentsMargins(0, 0, 0, 0);
+
+    const auto durLabel = new QLabel(QString::fromUtf8("时长:"), this);
+    {
+        QFont lf = durLabel->font();
+        lf.setPixelSize(11);
+        durLabel->setFont(lf);
+        durLabel->setStyleSheet(QStringLiteral("color: %1;")
+                                .arg(ThemeSupport::getThemeColorTextDisabled().name()));
+    }
+    ctrlRow->addWidget(durLabel);
+
+    mDurationSlider = new QSlider(Qt::Horizontal, this);
+    mDurationSlider->setRange(50, 300);
+    mDurationSlider->setSingleStep(10);
+    mDurationSlider->setValue(100);
+    mDurationSlider->setMaximumHeight(18);
+    mDurationSlider->setToolTip(QString::fromUtf8("动画时长缩放（%1%）"));
+    ctrlRow->addWidget(mDurationSlider, 1);
+
+    mDurationSpin = new QSpinBox(this);
+    mDurationSpin->setRange(50, 300);
+    mDurationSpin->setSuffix(QStringLiteral("%"));
+    mDurationSpin->setValue(100);
+    mDurationSpin->setFixedWidth(54);
+    mDurationSpin->setToolTip(QString::fromUtf8("动画时长缩放百分比"));
+    ctrlRow->addWidget(mDurationSpin);
+
+    mDurationResetBtn = new QPushButton(QString::fromUtf8("↺"), this);
+    mDurationResetBtn->setFixedSize(22, 22);
+    mDurationResetBtn->setCursor(Qt::PointingHandCursor);
+    mDurationResetBtn->setToolTip(QString::fromUtf8("重置时长缩放到 100%"));
+    mDurationResetBtn->setStyleSheet(QStringLiteral(
+        "QPushButton { background: %1; color: %2; border: 1px solid %3; border-radius: %4px; font-weight: bold; }"
+        "QPushButton:hover { background: %5; color: #ffffff; border-color: %6; }"
+    ).arg(ThemeSupport::getThemeButtonBaseColor().name(),
+          ThemeSupport::getThemeColorTextDisabled().name(),
+          ThemeSupport::getThemeButtonBorderColor().name(),
+          QString::number(ThemeSupport::borderRadius() > 4 ? 4 : ThemeSupport::borderRadius()),
+          ThemeSupport::getThemeButtonHoverColor().name(),
+          ThemeSupport::getThemeHighlightColor().name()));
+    connect(mDurationResetBtn, &QPushButton::clicked, this, [this]() {
+        mDurationSlider->setValue(100);
+    });
+    ctrlRow->addWidget(mDurationResetBtn);
+
+    const auto zoomLabel = new QLabel(QString::fromUtf8("视图:"), this);
+    {
+        QFont zf = zoomLabel->font();
+        zf.setPixelSize(11);
+        zoomLabel->setFont(zf);
+        zoomLabel->setStyleSheet(QStringLiteral("color: %1;")
+                                .arg(ThemeSupport::getThemeColorTextDisabled().name()));
+    }
+    ctrlRow->addWidget(zoomLabel);
+
+    mTileSizeSlider = new QSlider(Qt::Horizontal, this);
+    mTileSizeSlider->setRange(90, 200);
+    mTileSizeSlider->setSingleStep(10);
+    mTileSizeSlider->setValue(mTileSize);
+    mTileSizeSlider->setMaximumHeight(18);
+    mTileSizeSlider->setToolTip(QString::fromUtf8("预览卡片尺寸"));
+    ctrlRow->addWidget(mTileSizeSlider, 1);
+    footerLayout->addLayout(ctrlRow);
+
+    // Row 2: Status Indicator & Clear Button
+    const auto statusRow = new QHBoxLayout();
+    statusRow->setContentsMargins(0, 0, 0, 0);
+    statusRow->setSpacing(6);
+
+    mStatusDot = new QLabel(this);
+    mStatusDot->setFixedSize(8, 8);
+    mStatusDot->setStyleSheet(QStringLiteral("background-color: %1; border-radius: 4px;")
+                              .arg(ThemeSupport::getThemeHighlightColor().name()));
+    statusRow->addWidget(mStatusDot, 0, Qt::AlignVCenter);
 
     mStatusLabel = new QLabel(this);
     {
@@ -494,54 +754,56 @@ TextAnimPresetPanel::TextAnimPresetPanel(Document& doc,
         f.setPixelSize(11);
         mStatusLabel->setFont(f);
     }
-    mStatusLabel->setWordWrap(true);
-    mStatusLabel->setText(QString::fromUtf8("选择文字或图层后点入点/出点应用。"));
-    rootLayout->addWidget(mStatusLabel);
+    mStatusLabel->setWordWrap(false);
+    mStatusLabel->setStyleSheet(QStringLiteral("color: %1;")
+                                .arg(palette().color(QPalette::WindowText).name()));
+    statusRow->addWidget(mStatusLabel, 1, Qt::AlignVCenter);
 
-    // both sliders side by side at the very bottom; the duration one
-    // ends in an editable value box so the scale can be typed directly
-    const auto slidersRow = new QHBoxLayout();
-    slidersRow->setSpacing(6);
-    mDurationSlider = new QSlider(Qt::Horizontal, this);
-    mDurationSlider->setRange(50, 300);
-    mDurationSlider->setSingleStep(10);
-    mDurationSlider->setValue(100);
-    mDurationSlider->setMaximumHeight(18);
-    mDurationSlider->setToolTip(QString::fromUtf8("动画时长缩放（%1%）"));
-    slidersRow->addWidget(mDurationSlider, 1);
-    mDurationSpin = new QSpinBox(this);
-    mDurationSpin->setRange(50, 300);
-    mDurationSpin->setSuffix(QStringLiteral("%"));
-    mDurationSpin->setValue(100);
-    mDurationSpin->setFixedWidth(56);
-    mDurationSpin->setToolTip(QString::fromUtf8("动画时长缩放百分比，可直接输入"));
-    slidersRow->addWidget(mDurationSpin);
-    mTileSizeSlider = new QSlider(Qt::Horizontal, this);
-    mTileSizeSlider->setRange(90, 220);
-    mTileSizeSlider->setSingleStep(10);
-    mTileSizeSlider->setValue(mTileSize);
-    mTileSizeSlider->setMaximumHeight(18);
-    mTileSizeSlider->setToolTip(QString::fromUtf8("预览缩放"));
-    slidersRow->addWidget(mTileSizeSlider, 1);
-    rootLayout->addLayout(slidersRow);
+    mClearButton = new QPushButton(QString::fromUtf8("清除预设"), this);
+    {
+        QFont bf = mClearButton->font();
+        bf.setPixelSize(11);
+        mClearButton->setFont(bf);
+    }
+    mClearButton->setCursor(Qt::PointingHandCursor);
+    const QColor redCol = ThemeSupport::getThemeColorRed();
+    const int clearRad = ThemeSupport::borderRadius() > 4 ? 4 : ThemeSupport::borderRadius();
+    mClearButton->setStyleSheet(QStringLiteral(
+        "QPushButton {"
+        "  background: %1;"
+        "  color: %2;"
+        "  border: 1px solid %3;"
+        "  border-radius: %4px;"
+        "  padding: 3px 8px;"
+        "}"
+        "QPushButton:hover {"
+        "  background: %5;"
+        "  color: #ffffff;"
+        "  border-color: %2;"
+        "}"
+    ).arg(QColor(redCol.red(), redCol.green(), redCol.blue(), 35).name(QColor::HexArgb),
+          redCol.name(),
+          QColor(redCol.red(), redCol.green(), redCol.blue(), 90).name(QColor::HexArgb),
+          QString::number(clearRad),
+          QColor(redCol.red(), redCol.green(), redCol.blue(), 180).name(QColor::HexArgb)));
+    mClearButton->setToolTip(QString::fromUtf8("移除选中图层上已添加的预设表达式与文字特效"));
+    connect(mClearButton, &QPushButton::clicked, this, &TextAnimPresetPanel::clearSelectedPresets);
+    statusRow->addWidget(mClearButton, 0, Qt::AlignVCenter);
+
+    footerLayout->addLayout(statusRow);
+    rootLayout->addWidget(footerWidget);
+
     connect(mTileSizeSlider, &QSlider::valueChanged, this, [this](const int v) {
         mTileSize = v;
         for (const auto tile : mTiles) {
             tile->setPreviewSize(v);
-            tile->updateGeometry();
         }
-        // reflow: column count adapts to the new tile size
-        for (auto section : { &mTextSection, &mImageSection, &mLoopSection }) {
-            if (section->flow) {
-                section->flow->invalidate();
-                section->body->adjustSize();
-            }
+        if (mFlow) {
+            mFlow->invalidate();
+            mScrollHost->adjustSize();
         }
     });
 
-    // duration-scale changes re-render every tile (debounced - the
-    // preview must show the same timing the next Apply will bake,
-    // which it previously did not: previews were pinned to 100%)
     mDurationReRenderTimer = new QTimer(this);
     mDurationReRenderTimer->setSingleShot(true);
     mDurationReRenderTimer->setInterval(300);
@@ -551,7 +813,6 @@ TextAnimPresetPanel::TextAnimPresetPanel(Document& doc,
 
     connect(mDurationSlider, &QSlider::valueChanged, this, [this](const int v) {
         mDurationScale = v/100.;
-        // invalidates preview batches still rendering in the background
         mScaleGeneration++;
         mDurationSpin->blockSignals(true);
         mDurationSpin->setValue(v);
@@ -574,27 +835,20 @@ TextAnimPresetPanel::TextAnimPresetPanel(Document& doc,
     mPlayTimer->setInterval(40);
     connect(mPlayTimer, &QTimer::timeout, this, [this]() {
         for (const auto tile : mTiles) {
-            // skip tiles scrolled out of the viewport
             if (!tile->visibleRegion().isEmpty()) { tile->advance(); }
         }
     });
-
-    // build the default-open section lazily on first show
 }
 
-void TextAnimPresetPanel::buildSection(Section& section, const int kind)
+void TextAnimPresetPanel::buildAllTiles()
 {
-    section.built = true;
-    fillGridFromKind(kind, section.flow);
-}
+    if (mBuilt) { return; }
+    mBuilt = true;
 
-void TextAnimPresetPanel::fillGridFromKind(const int kind,
-                                           FlowLayout* flow)
-{
     QList<TextAnimTile*> added;
     const auto addTile = [&](const TextAnimPreset* const tp,
                              const LayerAnimPreset* const lp) {
-        const auto tile = new TextAnimTile(tp, lp, this);
+        const auto tile = new TextAnimTile(tp, lp, mScrollHost);
         connect(tile, &TextAnimTile::previewClicked,
                 this, [this](TextAnimTile* t) { selectTile(t); });
         connect(tile, &TextAnimTile::applyRequested,
@@ -602,27 +856,150 @@ void TextAnimPresetPanel::fillGridFromKind(const int kind,
             applyPreset(t, dir);
         });
         tile->setPreviewSize(mTileSize);
-        flow->addWidget(tile);
+        mFlow->addWidget(tile);
         mTiles << tile;
         added << tile;
     };
-    if (kind == 0) {
-        for (const auto& p : TextAnimPresets::all()) {
-            if (p.category == 0) { addTile(&p, nullptr); }
+
+    for (const auto& p : TextAnimPresets::all()) {
+        addTile(&p, nullptr);
+    }
+    for (const auto& p : LayerAnimPresets::all()) {
+        addTile(nullptr, &p);
+    }
+
+    updateCategoryCounts();
+    queueRender(added);
+}
+
+void TextAnimPresetPanel::updateCategoryCounts()
+{
+    if (!mCategoryGroup) { return; }
+    for (const auto btn : mCategoryGroup->buttons()) {
+        const QString tag = btn->property("filterTag").toString();
+        const QString baseLabel = btn->property("baseLabel").toString();
+        int count = 0;
+        for (const auto tile : mTiles) {
+            if (tile->matches(QString(), tag)) {
+                count++;
+            }
         }
-    } else if (kind == 1) {
-        for (const auto& p : LayerAnimPresets::all()) {
-            if (p.category == 0) { addTile(nullptr, &p); }
-        }
-    } else {
-        for (const auto& p : TextAnimPresets::all()) {
-            if (p.category == 2) { addTile(&p, nullptr); }
-        }
-        for (const auto& p : LayerAnimPresets::all()) {
-            if (p.category == 2) { addTile(nullptr, &p); }
+        btn->setText(QStringLiteral("%1 (%2)").arg(baseLabel).arg(count));
+    }
+}
+
+void TextAnimPresetPanel::filterPresets()
+{
+    if (!mBuilt) {
+        buildAllTiles();
+    }
+    const QString query = mSearchEdit ? mSearchEdit->text().trimmed() : QString();
+    int visibleCount = 0;
+    for (const auto tile : mTiles) {
+        const bool match = tile->matches(query, mActiveFilterTag);
+        tile->setVisible(match);
+        if (match) {
+            visibleCount++;
         }
     }
-    queueRender(added);
+    if (mFlow) {
+        mFlow->invalidate();
+        mScrollHost->adjustSize();
+    }
+    if (query.isEmpty() && mActiveFilterTag == QLatin1String("all")) {
+        setStatusText(QString::fromUtf8("全库共 %1 个动效预设 · 点击 [入] 或 [出] 快速应用").arg(mTiles.count()), StatusType::Normal);
+    } else {
+        setStatusText(QString::fromUtf8("筛选显示 %1 个预设（总库 %2 个）").arg(visibleCount).arg(mTiles.count()), StatusType::Normal);
+    }
+}
+
+void TextAnimPresetPanel::setStatusText(const QString& text, const StatusType type)
+{
+    if (mStatusLabel) {
+        mStatusLabel->setText(text);
+    }
+    if (mStatusDot) {
+        QString color;
+        switch (type) {
+        case StatusType::Success:
+            color = ThemeSupport::getThemeColorGreen().name();
+            break;
+        case StatusType::Warning:
+            color = ThemeSupport::getThemeColorOrange().name();
+            break;
+        case StatusType::Normal:
+        default:
+            color = ThemeSupport::getThemeHighlightColor().name();
+            break;
+        }
+        mStatusDot->setStyleSheet(QStringLiteral("background-color: %1; border-radius: 4px;").arg(color));
+    }
+}
+
+void TextAnimPresetPanel::clearSelectedPresets()
+{
+    const auto scene = mDocument.fActiveScene.data();
+    if (!scene) {
+        setStatusText(QString::fromUtf8("没有活动场景。"), StatusType::Warning);
+        return;
+    }
+    const auto selected = scene->getSelectedBoxesList();
+    if (selected.isEmpty()) {
+        setStatusText(QString::fromUtf8("请先选择图层。"), StatusType::Warning);
+        return;
+    }
+
+    selected.first()->prp_pushUndoRedoName(QString::fromUtf8("清除预设"));
+    int clearedCount = 0;
+    for (const auto& box : selected) {
+        bool changed = false;
+        if (const auto tb = dynamic_cast<TextBox*>(box)) {
+            if (const auto effects = tb->getTextEffects()) {
+                if (effects->hasEffects()) {
+                    effects->clear();
+                    changed = true;
+                }
+            }
+        }
+        if (const auto t = dynamic_cast<AdvancedTransformAnimator*>(box->getTransformAnimator())) {
+            const auto pos = t->getPosAnimator();
+            const auto scale = t->getScaleAnimator();
+            const auto rotA = t->getRotAnimator();
+            const auto opA = t->getOpacityAnimator();
+            const auto shear = t->getShearAnimator();
+            const auto rotX = t->getRotXAnimator();
+            const auto rotY = t->getRotYAnimator();
+            const auto zPos = t->getZPosAnimator();
+
+            const QList<QrealAnimator*> animators = {
+                pos ? pos->getXAnimator() : nullptr,
+                pos ? pos->getYAnimator() : nullptr,
+                scale ? scale->getXAnimator() : nullptr,
+                scale ? scale->getYAnimator() : nullptr,
+                rotA, opA,
+                shear ? shear->getXAnimator() : nullptr,
+                shear ? shear->getYAnimator() : nullptr,
+                rotX, rotY, zPos
+            };
+            for (const auto anim : animators) {
+                if (anim && anim->hasExpression()) {
+                    anim->setExpressionAction(nullptr);
+                    changed = true;
+                }
+            }
+        }
+        if (changed) {
+            clearedCount++;
+        }
+    }
+    Document::sInstance->actionFinished();
+    scene->updateAllBoxes(UpdateReason::userChange);
+
+    if (clearedCount > 0) {
+        setStatusText(QString::fromUtf8("已清除 %1 个图层上的动画预设。").arg(clearedCount), StatusType::Success);
+    } else {
+        setStatusText(QString::fromUtf8("所选图层未应用任何预设。"), StatusType::Normal);
+    }
 }
 
 void TextAnimPresetPanel::queueRender(const QList<TextAnimTile*>& tiles)
@@ -686,7 +1063,7 @@ void TextAnimPresetPanel::applyPreset(TextAnimTile* const tile,
     if (!tile) { return; }
     const auto scene = mDocument.fActiveScene.data();
     if (!scene) {
-        mStatusLabel->setText(QString::fromUtf8("没有活动场景。"));
+        setStatusText(QString::fromUtf8("没有活动场景。"), StatusType::Warning);
         return;
     }
     const qreal fps = scene->getFps();
@@ -694,17 +1071,17 @@ void TextAnimPresetPanel::applyPreset(TextAnimTile* const tile,
     if (const auto preset = tile->layerPreset()) {
         const auto selected = scene->getSelectedBoxesList();
         if (selected.isEmpty()) {
-            mStatusLabel->setText(QString::fromUtf8("请先选择图层。"));
+            setStatusText(QString::fromUtf8("请先选择图层。"), StatusType::Warning);
             return;
         }
         const qreal cw = scene->getCanvasWidth();
         const qreal ch = scene->getCanvasHeight();
         if (dir == 1 && !preset->outGen) {
-            mStatusLabel->setText(QString::fromUtf8("该预设不支持出点。"));
+            setStatusText(QString::fromUtf8("该预设不支持出点。"), StatusType::Warning);
             return;
         }
         if (dir == 0 && !preset->gen) {
-            mStatusLabel->setText(QString::fromUtf8("该预设不支持入点。"));
+            setStatusText(QString::fromUtf8("该预设不支持入点。"), StatusType::Warning);
             return;
         }
         // one undo block for the whole batch: the stack closes the
@@ -742,12 +1119,12 @@ void TextAnimPresetPanel::applyPreset(TextAnimTile* const tile,
         const QString dirText = dir == 0 ? QString::fromUtf8("（入点）") :
                 dir == 1 ? QString::fromUtf8("（出点）") :
                            QString::fromUtf8("（入+出）");
-        mStatusLabel->setText(
+        setStatusText(
                     QString::fromUtf8("已应用「%1%2」到 %3 个图层。")
                     .arg(preset->name).arg(dirText).arg(applied)
                 + (exitClamped ? QString::fromUtf8(
                        "有图层短于预设时长，出点已前移到入点。")
-                               : QString()));
+                               : QString()), StatusType::Success);
         Document::sInstance->actionFinished();
         scene->updateAllBoxes(UpdateReason::userChange);
         return;
@@ -756,12 +1133,12 @@ void TextAnimPresetPanel::applyPreset(TextAnimTile* const tile,
     const auto preset = tile->textPreset();
     if (!preset) { return; }
     if (dir == 1 && !preset->supportsOut) {
-        mStatusLabel->setText(QString::fromUtf8("该预设仅支持入点。"));
+        setStatusText(QString::fromUtf8("该预设仅支持入点。"), StatusType::Warning);
         return;
     }
     const auto targets = selectedTextBoxes();
     if (targets.isEmpty()) {
-        mStatusLabel->setText(QString::fromUtf8("请先选择文字图层。"));
+        setStatusText(QString::fromUtf8("请先选择文字图层。"), StatusType::Warning);
         return;
     }
     // one undo block for the whole batch (see the layer path above)
@@ -793,19 +1170,19 @@ void TextAnimPresetPanel::applyPreset(TextAnimTile* const tile,
         if (ok) { applied++; }
     }
     if (applied == 0) {
-        mStatusLabel->setText(preset->id == QLatin1String("number-roll")
+        setStatusText(preset->id == QLatin1String("number-roll")
             ? QString::fromUtf8("数字滚动需要文本包含数字（如“进度 42%”）。")
-            : QString::fromUtf8("预设应用失败。"));
+            : QString::fromUtf8("预设应用失败。"), StatusType::Warning);
     } else {
         const QString dirText = dir == 0 ? QString() :
                 dir == 1 ? QString::fromUtf8("（出点）") :
                            QString::fromUtf8("（入+出）");
-        mStatusLabel->setText(
+        setStatusText(
                     QString::fromUtf8("已应用「%1%2」到 %3 个文字层。")
                     .arg(preset->name).arg(dirText).arg(applied)
                 + (exitClamped ? QString::fromUtf8(
                        "有图层短于预设时长，出点已前移到入点。")
-                               : QString()));
+                               : QString()), StatusType::Success);
     }
     Document::sInstance->actionFinished();
     scene->updateAllBoxes(UpdateReason::userChange);
@@ -874,11 +1251,11 @@ const QString& TextAnimPresetPanel::defaultCjkFamily()
 void TextAnimPresetPanel::showEvent(QShowEvent* const e)
 {
     QWidget::showEvent(e);
-    if (mTextSection.expanded && !mTextSection.built) {
-        buildSection(mTextSection, 0);
+    if (!mBuilt) {
+        buildAllTiles();
+        filterPresets();
         if (!mTiles.isEmpty()) { selectTile(mTiles.first()); }
     } else if (mRenderAllOnShow) {
-        // renders requested while the panel was hidden
         mRenderAllOnShow = false;
         queueRender(mTiles);
     }

--- a/src/app/GUI/textanimpresetpanel.h
+++ b/src/app/GUI/textanimpresetpanel.h
@@ -61,19 +61,17 @@ public:
     { mChecked = checked; update(); }
     void setPreviewSize(const int size);
 
+    bool matches(const QString& query, const QString& filterTag) const;
+
     const TextAnimPreset* textPreset() const { return mTextPreset; }
     const LayerAnimPreset* layerPreset() const { return mLayerPreset; }
 
 protected:
     bool eventFilter(QObject* const obj, QEvent* const e) override;
-    void resizeEvent(QResizeEvent* const e) override;
     void paintEvent(QPaintEvent* const e) override;
     void enterEvent(QEvent* const e) override;
     void leaveEvent(QEvent* const e) override;
     QSize sizeHint() const override;
-
-private:
-    void repositionButtons();
 
     enum class Dir { in = 0, out = 1, all = 2 };
 
@@ -81,12 +79,12 @@ signals:
     void previewClicked(TextAnimTile* tile);
     void applyRequested(TextAnimTile* tile, int dir);
 
-
 private:
     const TextAnimPreset* mTextPreset = nullptr;
     const LayerAnimPreset* mLayerPreset = nullptr;
     class TextAnimPreview* mPreviewArea = nullptr;
     QLabel* mNameLabel = nullptr;
+    QLabel* mTagLabel = nullptr;
     QList<QPushButton*> mApplyButtons;
     bool mChecked = false;
     bool mHover = false;
@@ -104,7 +102,7 @@ public:
 
 protected:
     void paintEvent(QPaintEvent* const e) override;
-    QSize sizeHint() const override { return QSize(320, 132); }
+    QSize sizeHint() const override { return QSize(140, 140); }
 
 private:
     QList<QImage> mFrames;
@@ -112,18 +110,14 @@ private:
     QString mPlaceholder;
 };
 
-// Dockable animation preset browser: collapsible sections for
-// text / image / loop presets, animated square thumbnails with
-// per-preset IN (entrance) and OUT (exit) apply buttons, and a
-// big preview of the selected preset.
+// Dockable animation preset browser: clean category tab filter,
+// unobscured animated preview cards, separate button actions and
+// dual-row bottom control toolbar.
 class TextAnimPresetPanel : public QWidget {
     Q_OBJECT
 public:
     TextAnimPresetPanel(Document& doc, QWidget* const parent = nullptr);
 
-    // pause the thumbnail gallery animation while the main canvas
-    // preview plays: dozens of tiles repainting at 25 fps on the UI
-    // thread starve the playback timer and cause frame skips
     void setGalleryPaused(const bool paused);
 
 protected:
@@ -131,39 +125,43 @@ protected:
     void hideEvent(QHideEvent* const e) override;
 
 private:
-    struct Section {
-        QPushButton* header = nullptr;
-        QWidget* body = nullptr;
-        class FlowLayout* flow = nullptr;
-        bool built = false;
-        bool expanded = false;
-    };
+    enum class StatusType { Normal, Success, Warning };
 
-    void buildSection(Section& section, const int kind);
-    void fillGridFromKind(const int kind, FlowLayout* flow);
+    void buildAllTiles();
+    void updateCategoryCounts();
     // render preview frames for the given tiles on worker threads;
     // results are dropped if the duration scale changed mid-flight
     void queueRender(const QList<TextAnimTile*>& tiles);
     void selectTile(TextAnimTile* const tile);
     void applyPreset(TextAnimTile* const tile, const int dir);
+    void clearSelectedPresets();
+    void filterPresets();
+    void setStatusText(const QString& text, const StatusType type = StatusType::Normal);
+
     QList<TextBox*> selectedTextBoxes() const;
     QList<class BoundingBox*> selectedBoxes() const;
     const QImage& mascotImage();
     const QString& defaultCjkFamily();
 
     Document& mDocument;
-    Section mTextSection;
-    Section mImageSection;
-    Section mLoopSection;
+    class FlowLayout* mFlow = nullptr;
+    bool mBuilt = false;
     QTimer* mPlayTimer = nullptr;
+
+    class QLineEdit* mSearchEdit = nullptr;
+    class QButtonGroup* mCategoryGroup = nullptr;
+    QString mActiveFilterTag = QStringLiteral("all");
 
     QScrollArea* mScroll = nullptr;
     QWidget* mScrollHost = nullptr;
+    QLabel* mStatusDot = nullptr;
     QLabel* mStatusLabel = nullptr;
+    QPushButton* mClearButton = nullptr;
     QSlider* mDurationSlider = nullptr;
     QSpinBox* mDurationSpin = nullptr;
+    QPushButton* mDurationResetBtn = nullptr;
     QSlider* mTileSizeSlider = nullptr;
-    int mTileSize = 150;
+    int mTileSize = 130;
 
     QList<TextAnimTile*> mTiles;
     qreal mDurationScale = 1.0;

--- a/src/app/effects_unittest.cpp
+++ b/src/app/effects_unittest.cpp
@@ -39,6 +39,8 @@
 #include "themesupport.h"
 #include "AI/mcpserver.h"
 #include "AI/mcpdispatcher.h"
+#include "textanimpresets.h"
+#include "layeranimpresets.h"
 
 int main(int argc, char *argv[])
 {
@@ -749,6 +751,96 @@ int main(int argc, char *argv[])
         const auto listResult = listResp.value(QStringLiteral("result")).toObject();
         if (!listResult.contains(QStringLiteral("tools")) || !listResult.value(QStringLiteral("tools")).isArray()) {
             throw std::runtime_error("Invalid tools array in tools/list result");
+        }
+    });
+
+    // Test 8: Kinetic Text & Layer Animation Presets
+    runTest("Test 8: Kinetic Text & Layer Animation Presets", [&]() {
+        const auto& textPresets = TextAnimPresets::all();
+        if (textPresets.size() < 160) {
+            throw std::runtime_error(QString("Text presets count too low: %1 (expected >= 160)").arg(textPresets.size()).toStdString());
+        }
+
+        const auto& layerPresets = LayerAnimPresets::all();
+        if (layerPresets.size() < 60) {
+            throw std::runtime_error(QString("Layer presets count too low: %1 (expected >= 60)").arg(layerPresets.size()).toStdString());
+        }
+
+        const int totalPresets = textPresets.size() + layerPresets.size();
+        if (totalPresets < 220) {
+            throw std::runtime_error(QString("Total presets count too low: %1 (expected >= 220)").arg(totalPresets).toStdString());
+        }
+
+        // Verify key text presets from each archetype exist and have valid fields
+        const QStringList keyTextIds = {
+            "sharp-snap-rise", "sharp-elastic-pop", "sharp-blade-cut",
+            "sharp-double-bounce", "sharp-jelly-squash", "sharp-trampoline",
+            "smooth-float-rise", "smooth-cinematic-fade", "smooth-aurora",
+            "smooth-par-float", "smooth-bloom-slow",
+            "prop-pos-x-left", "prop-scale-uniform", "prop-rot-full-360", "prop-shear-slash-x",
+            "prop-scale-wide-8x",
+            "3d-flip-y-cw", "3d-corkscrew", "3d-barrel-roll", "3d-door-swing-left",
+            "tech-typewriter-std", "tech-number-roll", "tech-matrix-rain",
+            "tech-binary-matrix", "tech-crt-scan",
+            "loop-sine-wave", "loop-breathe-soft", "loop-heartbeat", "loop-rainbow-wave"
+        };
+        for (const auto& id : keyTextIds) {
+            const auto p = TextAnimPresets::byId(id);
+            if (!p) {
+                throw std::runtime_error(QString("Missing key text preset: %1").arg(id).toStdString());
+            }
+            if (p->name.isEmpty() || p->duration <= 0.0 || p->tag.isEmpty()) {
+                throw std::runtime_error(QString("Invalid data in text preset: %1").arg(id).toStdString());
+            }
+        }
+
+        // Verify key text presets have diverse and distinct physical easings
+        const auto snapPreset = TextAnimPresets::byId("sharp-snap-rise");
+        if (!snapPreset || snapPreset->easing != TextEasing::sharpSnap) {
+            throw std::runtime_error("sharp-snap-rise missing sharpSnap easing");
+        }
+        const auto bouncePreset = TextAnimPresets::byId("sharp-overshoot-down");
+        if (!bouncePreset || bouncePreset->easing != TextEasing::bounce) {
+            throw std::runtime_error("sharp-overshoot-down missing bounce easing");
+        }
+        const auto elasticPreset = TextAnimPresets::byId("sharp-elastic-pop");
+        if (!elasticPreset || elasticPreset->easing != TextEasing::elastic) {
+            throw std::runtime_error("sharp-elastic-pop missing elastic easing");
+        }
+        const auto anticipatePreset = TextAnimPresets::byId("3d-corkscrew");
+        if (!anticipatePreset || anticipatePreset->easing != TextEasing::anticipate) {
+            throw std::runtime_error("3d-corkscrew missing anticipate easing");
+        }
+        const auto steppedPreset = TextAnimPresets::byId("tech-typewriter-std");
+        if (!steppedPreset || steppedPreset->easing != TextEasing::stepped) {
+            throw std::runtime_error("tech-typewriter-std missing stepped easing");
+        }
+
+        // Verify TextEffect setups physics correctly
+        const auto effect = enve::make_shared<TextEffect>();
+        effect->setupFromPreset(*elasticPreset, 200.0, 48.0, 0, 30.0, 1.0);
+        if (!effect->hasCustomPhysics()) {
+            throw std::runtime_error("TextEffect failed to initialize custom physics");
+        }
+        if (effect->getEasing() != TextEasing::elastic) {
+            throw std::runtime_error("TextEffect easing mismatch");
+        }
+
+        // Verify key layer presets exist and have valid generators
+        const QStringList keyLayerIds = {
+            "l-fade", "l-pop", "l-drop", "l-flip-x",
+            "l-swing", "l-skew-slide", "l-elastic-scale", "l-orbit-3d",
+            "l-door-open-l", "l-dive-3d", "l-jelly-wobble", "l-heavy-stamp-jitter",
+            "l-sheet-slide-up", "l-glitch-shake", "l-heartbeat-layer"
+        };
+        for (const auto& id : keyLayerIds) {
+            const auto p = LayerAnimPresets::byId(id);
+            if (!p) {
+                throw std::runtime_error(QString("Missing key layer preset: %1").arg(id).toStdString());
+            }
+            if (p->name.isEmpty() || p->duration <= 0.0 || (!p->gen && !p->outGen)) {
+                throw std::runtime_error(QString("Invalid data or missing generator in layer preset: %1").arg(id).toStdString());
+            }
         }
     });
 

--- a/src/core/Expressions/expression.cpp
+++ b/src/core/Expressions/expression.cpp
@@ -68,8 +68,10 @@ void Expression::sAddDefinitionsTo(const QString& definitionsStr,
                                    QJSEngine& e)
 {
     QString defs;
-    const auto expressions = eSettings::sInstance->fExpressions.getDefinitions();
-    for (const auto &expr : expressions) { defs.append(expr.definitions); }
+    if (eSettings::sInstance) {
+        const auto expressions = eSettings::sInstance->fExpressions.getDefinitions();
+        for (const auto &expr : expressions) { defs.append(expr.definitions); }
+    }
     defs.append(definitionsStr);
 
     const auto defRet = e.evaluate(defs);

--- a/src/core/ReadWrite/evformat.h
+++ b/src/core/ReadWrite/evformat.h
@@ -83,6 +83,8 @@ namespace EvFormat {
         // in writeBoundingBox, after the package/layerKey block); older
         // files lack the byte and must skip it (positional)
         psdClippingMask = 45,
+        // Text animation preset physics curves & easing parameters
+        textPhysicsEasing = 46,
 
         nextVersion
     };

--- a/src/core/layeranimpresets.cpp
+++ b/src/core/layeranimpresets.cpp
@@ -297,11 +297,620 @@ void genWobble(const LayerExprParams& P, LayerExprScripts& S)
             .arg(f0, N(P.rot), d);
 }
 
+void genSlideInUp(const LayerExprParams& P, LayerExprScripts& S)
+{
+    S.posY = QStringLiteral(
+                "// 底部划入：从画布下方滑回原位\n"
+                "return %1 + %2 * (1 - pSmooth(pSeg(f, %3, %3 + %4)));")
+            .arg(N(P.py), N(P.ch/2 + P.bh), N(P.winF0()), N(P.D));
+}
+
+void genSlideOutUp(const LayerExprParams& P, LayerExprScripts& S)
+{
+    S.posY = QStringLiteral(
+                "// 向上划出：滑出画布上方\n"
+                "return %1 - %2 * pSmooth(pSeg(f, %3, %3 + %4));")
+            .arg(N(P.py), N(P.ch/2 + P.bh), N(P.winF0()), N(P.D));
+}
+
+void genSlideInDown(const LayerExprParams& P, LayerExprScripts& S)
+{
+    S.posY = QStringLiteral(
+                "// 顶部划入：从画布上方滑回原位\n"
+                "return %1 - %2 * (1 - pSmooth(pSeg(f, %3, %3 + %4)));")
+            .arg(N(P.py), N(P.ch/2 + P.bh), N(P.winF0()), N(P.D));
+}
+
+void genSlideOutDown(const LayerExprParams& P, LayerExprScripts& S)
+{
+    S.posY = QStringLiteral(
+                "// 向下划出：滑出画布下方\n"
+                "return %1 + %2 * pSmooth(pSeg(f, %3, %3 + %4));")
+            .arg(N(P.py), N(P.ch/2 + P.bh), N(P.winF0()), N(P.D));
+}
+
+void genZoomFarIn(const LayerExprParams& P, LayerExprScripts& S)
+{
+    const auto f0 = N(P.winF0());
+    const auto d = N(P.D);
+    S.scaleX = QStringLiteral(
+                "return %1 * (1 + 3.0 * (1 - pSmooth(pSeg(f, %2, %2 + %3))));")
+            .arg(N(P.sx), f0, d);
+    S.scaleY = QStringLiteral(
+                "return %1 * (1 + 3.0 * (1 - pSmooth(pSeg(f, %2, %2 + %3))));")
+            .arg(N(P.sy), f0, d);
+    S.op = QStringLiteral(
+                "return %1 * pSmooth(pSeg(f, %2, %2 + %3));")
+            .arg(N(P.op), f0, d);
+}
+
+void genZoomFarOut(const LayerExprParams& P, LayerExprScripts& S)
+{
+    const auto f0 = N(P.winF0());
+    const auto d = N(P.D);
+    S.scaleX = QStringLiteral(
+                "return %1 * (1 + 3.0 * pSmooth(pSeg(f, %2, %2 + %3)));")
+            .arg(N(P.sx), f0, d);
+    S.scaleY = QStringLiteral(
+                "return %1 * (1 + 3.0 * pSmooth(pSeg(f, %2, %2 + %3)));")
+            .arg(N(P.sy), f0, d);
+    S.op = QStringLiteral(
+                "return %1 * (1 - pSmooth(pSeg(f, %2, %2 + %3)));")
+            .arg(N(P.op), f0, d);
+}
+
+void genElasticScale(const LayerExprParams& P, LayerExprScripts& S)
+{
+    const auto f0 = N(P.winF0());
+    const auto d = N(P.D);
+    S.scaleX = QStringLiteral(
+                "return %1 * pPw((f - %2) / %3,"
+                " [[0, 0.001], [0.8, 1.25], [1.1, 0.9], [1.35, 1.05], [1.6, 1]]);")
+            .arg(N(P.sx), f0, d);
+    S.scaleY = QStringLiteral(
+                "return %1 * pPw((f - %2) / %3,"
+                " [[0, 0.001], [0.8, 1.25], [1.1, 0.9], [1.35, 1.05], [1.6, 1]]);")
+            .arg(N(P.sy), f0, d);
+    S.op = QStringLiteral(
+                "return %1 * pSmooth(pSeg(f, %2, %2 + %3));")
+            .arg(N(P.op), f0, N(qMax(1., P.D / 3.)));
+}
+
+void genSwingIn(const LayerExprParams& P, LayerExprScripts& S)
+{
+    const auto f0 = N(P.winF0());
+    const auto d = N(P.D);
+    S.rot = QStringLiteral(
+                "return %1 + pPw((f - %2) / %3,"
+                " [[0, 50], [0.7, -22], [1.1, 10], [1.4, -4], [1.7, 0]]);")
+            .arg(N(P.rot), f0, d);
+    S.op = QStringLiteral(
+                "return %1 * pSmooth(pSeg(f, %2, %2 + %3));")
+            .arg(N(P.op), f0, N(qMax(1., P.D / 3.)));
+}
+
+void genSwingOut(const LayerExprParams& P, LayerExprScripts& S)
+{
+    const auto f0 = N(P.winF0());
+    const auto d = N(P.D);
+    S.rot = QStringLiteral(
+                "return %1 - 50 * pSmooth(pSeg(f, %2, %2 + %3));")
+            .arg(N(P.rot), f0, d);
+    S.op = QStringLiteral(
+                "return %1 * (1 - pSmooth(pSeg(f, %2 + %3, %2 + %4)));")
+            .arg(N(P.op), f0, N(0.6 * P.D), d);
+}
+
+void genStampIn(const LayerExprParams& P, LayerExprScripts& S)
+{
+    const auto f0 = N(P.winF0());
+    const auto d = N(P.D);
+    S.scaleX = QStringLiteral(
+                "return %1 * pPw((f - %2) / %3,"
+                " [[0, 2.6], [0.8, 0.95], [1.0, 1.04], [1.2, 1.0]]);")
+            .arg(N(P.sx), f0, d);
+    S.scaleY = QStringLiteral(
+                "return %1 * pPw((f - %2) / %3,"
+                " [[0, 2.6], [0.8, 0.95], [1.0, 1.04], [1.2, 1.0]]);")
+            .arg(N(P.sy), f0, d);
+    S.op = QStringLiteral(
+                "return %1 * pSmooth(pSeg(f, %2, %2 + %3));")
+            .arg(N(P.op), f0, N(qMax(1., P.D / 3.)));
+}
+
+void genExpandHIn(const LayerExprParams& P, LayerExprScripts& S)
+{
+    S.scaleX = QStringLiteral("return %1 * pSmooth(pSeg(f, %2, %2 + %3));")
+            .arg(N(P.sx), N(P.winF0()), N(P.D));
+}
+
+void genExpandHOut(const LayerExprParams& P, LayerExprScripts& S)
+{
+    S.scaleX = QStringLiteral("return %1 * (1 - pSmooth(pSeg(f, %2, %2 + %3)));")
+            .arg(N(P.sx), N(P.winF0()), N(P.D));
+}
+
+void genExpandVIn(const LayerExprParams& P, LayerExprScripts& S)
+{
+    S.scaleY = QStringLiteral("return %1 * pSmooth(pSeg(f, %2, %2 + %3));")
+            .arg(N(P.sy), N(P.winF0()), N(P.D));
+}
+
+void genExpandVOut(const LayerExprParams& P, LayerExprScripts& S)
+{
+    S.scaleY = QStringLiteral("return %1 * (1 - pSmooth(pSeg(f, %2, %2 + %3)));")
+            .arg(N(P.sy), N(P.winF0()), N(P.D));
+}
+
+void genSkewSlideInLeft(const LayerExprParams& P, LayerExprScripts& S)
+{
+    const auto f0 = N(P.winF0());
+    const auto d = N(P.D);
+    S.posX = QStringLiteral("return %1 - %2 * (1 - pSmooth(pSeg(f, %3, %3 + %4)));")
+            .arg(N(P.px), N(P.cw/2 + P.bw), f0, d);
+    S.shearX = QStringLiteral("return %1 + 0.7 * (1 - pSmooth(pSeg(f, %2, %2 + %3)));")
+            .arg(N(P.shx), f0, d);
+}
+
+void genSkewSlideOutLeft(const LayerExprParams& P, LayerExprScripts& S)
+{
+    const auto f0 = N(P.winF0());
+    const auto d = N(P.D);
+    S.posX = QStringLiteral("return %1 - %2 * pSmooth(pSeg(f, %3, %3 + %4));")
+            .arg(N(P.px), N(P.cw/2 + P.bw), f0, d);
+    S.shearX = QStringLiteral("return %1 - 0.7 * pSmooth(pSeg(f, %2, %2 + %3));")
+            .arg(N(P.shx), f0, d);
+}
+
+void genSkewSlideInRight(const LayerExprParams& P, LayerExprScripts& S)
+{
+    const auto f0 = N(P.winF0());
+    const auto d = N(P.D);
+    S.posX = QStringLiteral("return %1 + %2 * (1 - pSmooth(pSeg(f, %3, %3 + %4)));")
+            .arg(N(P.px), N(P.cw/2 + P.bw), f0, d);
+    S.shearX = QStringLiteral("return %1 - 0.7 * (1 - pSmooth(pSeg(f, %2, %2 + %3)));")
+            .arg(N(P.shx), f0, d);
+}
+
+void genSkewSlideOutRight(const LayerExprParams& P, LayerExprScripts& S)
+{
+    const auto f0 = N(P.winF0());
+    const auto d = N(P.D);
+    S.posX = QStringLiteral("return %1 + %2 * pSmooth(pSeg(f, %3, %3 + %4));")
+            .arg(N(P.px), N(P.cw/2 + P.bw), f0, d);
+    S.shearX = QStringLiteral("return %1 + 0.7 * pSmooth(pSeg(f, %2, %2 + %3));")
+            .arg(N(P.shx), f0, d);
+}
+
+void genFlipXIn(const LayerExprParams& P, LayerExprScripts& S)
+{
+    const auto f0 = N(P.winF0());
+    const auto d = N(P.D);
+    S.rotX = QStringLiteral("return %1 + 90 * (1 - pSmooth(pSeg(f, %2, %2 + %3)));")
+            .arg(N(P.rx), f0, d);
+    S.op = QStringLiteral("return %1 * pSmooth(pSeg(f, %2, %2 + %3));")
+            .arg(N(P.op), f0, N(qMax(1., P.D / 2.)));
+}
+
+void genFlipXOut(const LayerExprParams& P, LayerExprScripts& S)
+{
+    const auto f0 = N(P.winF0());
+    const auto d = N(P.D);
+    S.rotX = QStringLiteral("return %1 - 90 * pSmooth(pSeg(f, %2, %2 + %3));")
+            .arg(N(P.rx), f0, d);
+    S.op = QStringLiteral("return %1 * (1 - pSmooth(pSeg(f, %2 + %3, %2 + %4)));")
+            .arg(N(P.op), f0, N(0.5 * P.D), d);
+}
+
+void genFlipYIn(const LayerExprParams& P, LayerExprScripts& S)
+{
+    const auto f0 = N(P.winF0());
+    const auto d = N(P.D);
+    S.rotY = QStringLiteral("return %1 - 90 * (1 - pSmooth(pSeg(f, %2, %2 + %3)));")
+            .arg(N(P.ry), f0, d);
+    S.op = QStringLiteral("return %1 * pSmooth(pSeg(f, %2, %2 + %3));")
+            .arg(N(P.op), f0, N(qMax(1., P.D / 2.)));
+}
+
+void genFlipYOut(const LayerExprParams& P, LayerExprScripts& S)
+{
+    const auto f0 = N(P.winF0());
+    const auto d = N(P.D);
+    S.rotY = QStringLiteral("return %1 + 90 * pSmooth(pSeg(f, %2, %2 + %3));")
+            .arg(N(P.ry), f0, d);
+    S.op = QStringLiteral("return %1 * (1 - pSmooth(pSeg(f, %2 + %3, %2 + %4)));")
+            .arg(N(P.op), f0, N(0.5 * P.D), d);
+}
+
+void genFlyIn3D(const LayerExprParams& P, LayerExprScripts& S)
+{
+    const auto f0 = N(P.winF0());
+    const auto d = N(P.D);
+    S.posZ = QStringLiteral("return %1 - 900 * (1 - pSmooth(pSeg(f, %2, %2 + %3)));")
+            .arg(N(P.pz), f0, d);
+    S.op = QStringLiteral("return %1 * pSmooth(pSeg(f, %2, %2 + %3));")
+            .arg(N(P.op), f0, N(qMax(1., P.D / 3.)));
+}
+
+void genFlyOut3D(const LayerExprParams& P, LayerExprScripts& S)
+{
+    const auto f0 = N(P.winF0());
+    const auto d = N(P.D);
+    S.posZ = QStringLiteral("return %1 + 900 * pSmooth(pSeg(f, %2, %2 + %3));")
+            .arg(N(P.pz), f0, d);
+    S.op = QStringLiteral("return %1 * (1 - pSmooth(pSeg(f, %2 + %3, %2 + %4)));")
+            .arg(N(P.op), f0, N(0.6 * P.D), d);
+}
+
+void genSinkIn(const LayerExprParams& P, LayerExprScripts& S)
+{
+    const auto f0 = N(P.winF0());
+    const auto d = N(P.D);
+    S.posY = QStringLiteral("return %1 + %2 * (1 - pSmooth(pSeg(f, %3, %3 + %4)));")
+            .arg(N(P.py), N(P.bh + 40.), f0, d);
+    S.op = QStringLiteral("return %1 * pSmooth(pSeg(f, %2, %2 + %3));")
+            .arg(N(P.op), f0, d);
+}
+
+void genFloat(const LayerExprParams& P, LayerExprScripts& S)
+{
+    S.posY = QStringLiteral(
+                "if (f < %1) { return %2; }\n"
+                "return %2 + 10 * Math.sin(2 * Math.PI * pPh(f, %1, %3));")
+            .arg(N(P.winF0()), N(P.py), N(P.D));
+}
+
+void genSpinLoop(const LayerExprParams& P, LayerExprScripts& S)
+{
+    S.rot = QStringLiteral(
+                "if (f < %1) { return %2; }\n"
+                "return %2 + 360 * pPh(f, %1, %3);")
+            .arg(N(P.winF0()), N(P.rot), N(P.D));
+}
+
+void genPulseScale(const LayerExprParams& P, LayerExprScripts& S)
+{
+    const auto f0 = N(P.winF0());
+    const auto d = N(P.D);
+    S.scaleX = QStringLiteral(
+                "if (f < %1) { return %2; }\n"
+                "return %2 * (1 + 0.16 * (0.5 - 0.5 * Math.cos(2 * Math.PI * pPh(f, %1, %3))));")
+            .arg(f0, N(P.sx), d);
+    S.scaleY = QStringLiteral(
+                "if (f < %1) { return %2; }\n"
+                "return %2 * (1 + 0.16 * (0.5 - 0.5 * Math.cos(2 * Math.PI * pPh(f, %1, %3))));")
+            .arg(f0, N(P.sy), d);
+}
+
+void genPendulum(const LayerExprParams& P, LayerExprScripts& S)
+{
+    S.rot = QStringLiteral(
+                "if (f < %1) { return %2; }\n"
+                "return %2 + 15 * Math.sin(2 * Math.PI * pPh(f, %1, %3));")
+            .arg(N(P.winF0()), N(P.rot), N(P.D));
+}
+
+void genJiggle(const LayerExprParams& P, LayerExprScripts& S)
+{
+    const auto f0 = N(P.winF0());
+    const auto d = N(P.D);
+    S.scaleX = QStringLiteral(
+                "if (f < %1) { return %2; }\n"
+                "return %2 * (1 + 0.08 * Math.sin(4 * Math.PI * pPh(f, %1, %3)));")
+            .arg(f0, N(P.sx), d);
+    S.scaleY = QStringLiteral(
+                "if (f < %1) { return %2; }\n"
+                "return %2 * (1 - 0.08 * Math.sin(4 * Math.PI * pPh(f, %1, %3)));")
+            .arg(f0, N(P.sy), d);
+}
+
+void genOrbit3D(const LayerExprParams& P, LayerExprScripts& S)
+{
+    const auto f0 = N(P.winF0());
+    const auto d = N(P.D);
+    S.rotX = QStringLiteral(
+                "if (f < %1) { return %2; }\n"
+                "return %2 + 10 * Math.sin(2 * Math.PI * pPh(f, %1, %3));")
+            .arg(f0, N(P.rx), d);
+    S.rotY = QStringLiteral(
+                "if (f < %1) { return %2; }\n"
+                "return %2 + 14 * Math.cos(2 * Math.PI * pPh(f, %1, %3));")
+            .arg(f0, N(P.ry), d);
+}
+
+// ---------------- 3D Space Extensions
+void genDoorOpenLIn(const LayerExprParams& P, LayerExprScripts& S)
+{
+    const auto f0 = N(P.winF0()), d = N(P.D);
+    S.rotY = QStringLiteral("return %1 - 90 * (1 - pSmooth(pSeg(f, %2, %2 + %3)));").arg(N(P.ry), f0, d);
+    S.op = QStringLiteral("return %1 * pSmooth(pSeg(f, %2, %2 + %3));").arg(N(P.op), f0, N(qMax(1., P.D / 2.)));
+}
+void genDoorOpenLOut(const LayerExprParams& P, LayerExprScripts& S)
+{
+    const auto f0 = N(P.winF0()), d = N(P.D);
+    S.rotY = QStringLiteral("return %1 - 90 * pSmooth(pSeg(f, %2, %2 + %3));").arg(N(P.ry), f0, d);
+    S.op = QStringLiteral("return %1 * (1 - pSmooth(pSeg(f, %2 + %3, %2 + %4)));").arg(N(P.op), f0, N(0.5 * P.D), d);
+}
+void genDoorOpenRIn(const LayerExprParams& P, LayerExprScripts& S)
+{
+    const auto f0 = N(P.winF0()), d = N(P.D);
+    S.rotY = QStringLiteral("return %1 + 90 * (1 - pSmooth(pSeg(f, %2, %2 + %3)));").arg(N(P.ry), f0, d);
+    S.op = QStringLiteral("return %1 * pSmooth(pSeg(f, %2, %2 + %3));").arg(N(P.op), f0, N(qMax(1., P.D / 2.)));
+}
+void genDoorOpenROut(const LayerExprParams& P, LayerExprScripts& S)
+{
+    const auto f0 = N(P.winF0()), d = N(P.D);
+    S.rotY = QStringLiteral("return %1 + 90 * pSmooth(pSeg(f, %2, %2 + %3));").arg(N(P.ry), f0, d);
+    S.op = QStringLiteral("return %1 * (1 - pSmooth(pSeg(f, %2 + %3, %2 + %4)));").arg(N(P.op), f0, N(0.5 * P.D), d);
+}
+void genDive3DIn(const LayerExprParams& P, LayerExprScripts& S)
+{
+    const auto f0 = N(P.winF0()), d = N(P.D);
+    S.rotX = QStringLiteral("return %1 + 60 * (1 - pSmooth(pSeg(f, %2, %2 + %3)));").arg(N(P.rx), f0, d);
+    S.posZ = QStringLiteral("return %1 - 600 * (1 - pSmooth(pSeg(f, %2, %2 + %3)));").arg(N(P.pz), f0, d);
+    S.op = QStringLiteral("return %1 * pSmooth(pSeg(f, %2, %2 + %3));").arg(N(P.op), f0, d);
+}
+void genDive3DOut(const LayerExprParams& P, LayerExprScripts& S)
+{
+    const auto f0 = N(P.winF0()), d = N(P.D);
+    S.rotX = QStringLiteral("return %1 + 60 * pSmooth(pSeg(f, %2, %2 + %3));").arg(N(P.rx), f0, d);
+    S.posZ = QStringLiteral("return %1 - 600 * pSmooth(pSeg(f, %2, %2 + %3));").arg(N(P.pz), f0, d);
+    S.op = QStringLiteral("return %1 * (1 - pSmooth(pSeg(f, %2, %2 + %3)));").arg(N(P.op), f0, d);
+}
+void genClimb3DIn(const LayerExprParams& P, LayerExprScripts& S)
+{
+    const auto f0 = N(P.winF0()), d = N(P.D);
+    S.rotX = QStringLiteral("return %1 - 60 * (1 - pSmooth(pSeg(f, %2, %2 + %3)));").arg(N(P.rx), f0, d);
+    S.posZ = QStringLiteral("return %1 + 600 * (1 - pSmooth(pSeg(f, %2, %2 + %3)));").arg(N(P.pz), f0, d);
+    S.op = QStringLiteral("return %1 * pSmooth(pSeg(f, %2, %2 + %3));").arg(N(P.op), f0, d);
+}
+void genClimb3DOut(const LayerExprParams& P, LayerExprScripts& S)
+{
+    const auto f0 = N(P.winF0()), d = N(P.D);
+    S.rotX = QStringLiteral("return %1 - 60 * pSmooth(pSeg(f, %2, %2 + %3));").arg(N(P.rx), f0, d);
+    S.posZ = QStringLiteral("return %1 + 600 * pSmooth(pSeg(f, %2, %2 + %3));").arg(N(P.pz), f0, d);
+    S.op = QStringLiteral("return %1 * (1 - pSmooth(pSeg(f, %2, %2 + %3)));").arg(N(P.op), f0, d);
+}
+void genAxialRollIn(const LayerExprParams& P, LayerExprScripts& S)
+{
+    const auto f0 = N(P.winF0()), d = N(P.D);
+    S.rotX = QStringLiteral("return %1 + 180 * (1 - pSmooth(pSeg(f, %2, %2 + %3)));").arg(N(P.rx), f0, d);
+    S.rotY = QStringLiteral("return %1 + 180 * (1 - pSmooth(pSeg(f, %2, %2 + %3)));").arg(N(P.ry), f0, d);
+    S.op = QStringLiteral("return %1 * pSmooth(pSeg(f, %2, %2 + %3));").arg(N(P.op), f0, d);
+}
+void genAxialRollOut(const LayerExprParams& P, LayerExprScripts& S)
+{
+    const auto f0 = N(P.winF0()), d = N(P.D);
+    S.rotX = QStringLiteral("return %1 + 180 * pSmooth(pSeg(f, %2, %2 + %3));").arg(N(P.rx), f0, d);
+    S.rotY = QStringLiteral("return %1 + 180 * pSmooth(pSeg(f, %2, %2 + %3));").arg(N(P.ry), f0, d);
+    S.op = QStringLiteral("return %1 * (1 - pSmooth(pSeg(f, %2, %2 + %3)));").arg(N(P.op), f0, d);
+}
+void genTiltSwayIn(const LayerExprParams& P, LayerExprScripts& S)
+{
+    const auto f0 = N(P.winF0()), d = N(P.D);
+    S.rotX = QStringLiteral("return %1 + 25 * (1 - pSmooth(pSeg(f, %2, %2 + %3)));").arg(N(P.rx), f0, d);
+    S.rotY = QStringLiteral("return %1 - 25 * (1 - pSmooth(pSeg(f, %2, %2 + %3)));").arg(N(P.ry), f0, d);
+    S.op = QStringLiteral("return %1 * pSmooth(pSeg(f, %2, %2 + %3));").arg(N(P.op), f0, d);
+}
+void genTiltSwayOut(const LayerExprParams& P, LayerExprScripts& S)
+{
+    const auto f0 = N(P.winF0()), d = N(P.D);
+    S.rotX = QStringLiteral("return %1 - 25 * pSmooth(pSeg(f, %2, %2 + %3));").arg(N(P.rx), f0, d);
+    S.rotY = QStringLiteral("return %1 + 25 * pSmooth(pSeg(f, %2, %2 + %3));").arg(N(P.ry), f0, d);
+    S.op = QStringLiteral("return %1 * (1 - pSmooth(pSeg(f, %2, %2 + %3)));").arg(N(P.op), f0, d);
+}
+void genIsometricDrop(const LayerExprParams& P, LayerExprScripts& S)
+{
+    const auto f0 = N(P.winF0()), d = N(P.D);
+    S.rotX = QStringLiteral("return %1 + 30 * (1 - pSmooth(pSeg(f, %2, %2 + %3)));").arg(N(P.rx), f0, d);
+    S.rotY = QStringLiteral("return %1 + 45 * (1 - pSmooth(pSeg(f, %2, %2 + %3)));").arg(N(P.ry), f0, d);
+    S.posY = QStringLiteral("return %1 - 220 * (1 - pSmooth(pSeg(f, %2, %2 + %3)));").arg(N(P.py), f0, d);
+    S.op = QStringLiteral("return %1 * pSmooth(pSeg(f, %2, %2 + %3));").arg(N(P.op), f0, d);
+}
+void genDepthZoomBurstIn(const LayerExprParams& P, LayerExprScripts& S)
+{
+    const auto f0 = N(P.winF0()), d = N(P.D);
+    S.posZ = QStringLiteral("return %1 - 1500 * (1 - pSmooth(pSeg(f, %2, %2 + %3)));").arg(N(P.pz), f0, d);
+    S.scaleX = QStringLiteral("return %1 * (0.1 + 0.9 * pSmooth(pSeg(f, %2, %2 + %3)));").arg(N(P.sx), f0, d);
+    S.scaleY = QStringLiteral("return %1 * (0.1 + 0.9 * pSmooth(pSeg(f, %2, %2 + %3)));").arg(N(P.sy), f0, d);
+    S.op = QStringLiteral("return %1 * pSmooth(pSeg(f, %2, %2 + %3));").arg(N(P.op), f0, d);
+}
+void genDepthZoomBurstOut(const LayerExprParams& P, LayerExprScripts& S)
+{
+    const auto f0 = N(P.winF0()), d = N(P.D);
+    S.posZ = QStringLiteral("return %1 + 1500 * pSmooth(pSeg(f, %2, %2 + %3));").arg(N(P.pz), f0, d);
+    S.scaleX = QStringLiteral("return %1 * (1 + 2.0 * pSmooth(pSeg(f, %2, %2 + %3)));").arg(N(P.sx), f0, d);
+    S.scaleY = QStringLiteral("return %1 * (1 + 2.0 * pSmooth(pSeg(f, %2, %2 + %3)));").arg(N(P.sy), f0, d);
+    S.op = QStringLiteral("return %1 * (1 - pSmooth(pSeg(f, %2, %2 + %3)));").arg(N(P.op), f0, d);
+}
+void genCardUnfold3DIn(const LayerExprParams& P, LayerExprScripts& S)
+{
+    const auto f0 = N(P.winF0()), d = N(P.D);
+    S.rotY = QStringLiteral("return %1 - 90 * (1 - pSmooth(pSeg(f, %2, %2 + %3)));").arg(N(P.ry), f0, d);
+    S.rotX = QStringLiteral("return %1 - 45 * (1 - pSmooth(pSeg(f, %2, %2 + %3)));").arg(N(P.rx), f0, d);
+    S.op = QStringLiteral("return %1 * pSmooth(pSeg(f, %2, %2 + %3));").arg(N(P.op), f0, d);
+}
+void genCardUnfold3DOut(const LayerExprParams& P, LayerExprScripts& S)
+{
+    const auto f0 = N(P.winF0()), d = N(P.D);
+    S.rotY = QStringLiteral("return %1 + 90 * pSmooth(pSeg(f, %2, %2 + %3));").arg(N(P.ry), f0, d);
+    S.rotX = QStringLiteral("return %1 + 45 * pSmooth(pSeg(f, %2, %2 + %3));").arg(N(P.rx), f0, d);
+    S.op = QStringLiteral("return %1 * (1 - pSmooth(pSeg(f, %2, %2 + %3)));").arg(N(P.op), f0, d);
+}
+void genOrbitHelix(const LayerExprParams& P, LayerExprScripts& S)
+{
+    const auto f0 = N(P.winF0()), d = N(P.D);
+    S.rotX = QStringLiteral("if (f < %1) return %2; return %2 + 18 * Math.sin(2 * Math.PI * pPh(f, %1, %3));").arg(f0, N(P.rx), d);
+    S.rotY = QStringLiteral("if (f < %1) return %2; return %2 + 22 * Math.cos(2 * Math.PI * pPh(f, %1, %3));").arg(f0, N(P.ry), d);
+    S.posZ = QStringLiteral("if (f < %1) return %2; return %2 + 120 * Math.sin(4 * Math.PI * pPh(f, %1, %3));").arg(f0, N(P.pz), d);
+}
+
+// ---------------- Physical Dynamics Extensions
+void genJellyWobble(const LayerExprParams& P, LayerExprScripts& S)
+{
+    const auto f0 = N(P.winF0()), d = N(P.D);
+    S.scaleX = QStringLiteral("var t = pSeg(f, %1, %1 + %2); return %3 * (1 + 0.45 * Math.sin(t * 12) * Math.exp(-4 * t));").arg(f0, d, N(P.sx));
+    S.scaleY = QStringLiteral("var t = pSeg(f, %1, %1 + %2); return %3 * (1 - 0.45 * Math.sin(t * 12) * Math.exp(-4 * t));").arg(f0, d, N(P.sy));
+    S.op = QStringLiteral("return %1 * pSmooth(pSeg(f, %2, %2 + %3));").arg(N(P.op), f0, N(qMax(1., P.D / 3.)));
+}
+void genRubberBounce(const LayerExprParams& P, LayerExprScripts& S)
+{
+    const auto f0 = N(P.winF0()), d = N(P.D);
+    S.posY = QStringLiteral("var t = pSeg(f, %1, %1 + %2); return %3 - 200 * Math.abs(Math.cos(t * Math.PI * 2.5)) * Math.exp(-3 * t);").arg(f0, d, N(P.py));
+    S.scaleY = QStringLiteral("var t = pSeg(f, %1, %1 + %2); return %3 * (1 + 0.3 * Math.sin(t * 10) * Math.exp(-3.5 * t));").arg(f0, d, N(P.sy));
+    S.op = QStringLiteral("return %1 * pSmooth(pSeg(f, %2, %2 + %3));").arg(N(P.op), f0, N(qMax(1., P.D / 4.)));
+}
+void genHeavyStampJitter(const LayerExprParams& P, LayerExprScripts& S)
+{
+    const auto f0 = N(P.winF0()), d = N(P.D);
+    S.posY = QStringLiteral("var t = pSeg(f, %1, %1 + %2); return %3 - 250 * Math.pow(1 - t, 3);").arg(f0, d, N(P.py));
+    S.scaleX = QStringLiteral("var t = pSeg(f, %1, %1 + %2); return %3 * (1 + 0.3 * Math.sin(t * 20) * Math.exp(-5 * t));").arg(f0, d, N(P.sx));
+    S.scaleY = QStringLiteral("var t = pSeg(f, %1, %1 + %2); return %3 * (1 - 0.25 * Math.sin(t * 20) * Math.exp(-5 * t));").arg(f0, d, N(P.sy));
+    S.op = QStringLiteral("return %1 * pSmooth(pSeg(f, %2, %2 + %3));").arg(N(P.op), f0, N(qMax(1., P.D / 4.)));
+}
+void genMagneticSnap(const LayerExprParams& P, LayerExprScripts& S)
+{
+    const auto f0 = N(P.winF0()), d = N(P.D);
+    S.posX = QStringLiteral("var t = pSeg(f, %1, %1 + %2); return %3 - 180 * (1 - (1 - Math.pow(2, -10 * t)));").arg(f0, d, N(P.px));
+    S.shearX = QStringLiteral("var t = pSeg(f, %1, %1 + %2); return %3 + 0.35 * Math.sin(t * 14) * Math.exp(-4 * t);").arg(f0, d, N(P.shx));
+    S.op = QStringLiteral("return %1 * pSmooth(pSeg(f, %2, %2 + %3));").arg(N(P.op), f0, N(qMax(1., P.D / 4.)));
+}
+void genPendulumSettle(const LayerExprParams& P, LayerExprScripts& S)
+{
+    const auto f0 = N(P.winF0()), d = N(P.D);
+    S.rot = QStringLiteral("var t = pSeg(f, %1, %1 + %2); return %3 + 45 * Math.cos(t * 10) * Math.exp(-3 * t);").arg(f0, d, N(P.rot));
+    S.op = QStringLiteral("return %1 * pSmooth(pSeg(f, %2, %2 + %3));").arg(N(P.op), f0, N(qMax(1., P.D / 3.)));
+}
+void genBalloonFloat(const LayerExprParams& P, LayerExprScripts& S)
+{
+    const auto f0 = N(P.winF0()), d = N(P.D);
+    S.posY = QStringLiteral("return %1 + 180 * (1 - pSmooth(pSeg(f, %2, %2 + %3)));").arg(N(P.py), f0, d);
+    S.rot = QStringLiteral("var t = pSeg(f, %1, %1 + %2); return %3 + 8 * Math.sin(t * 8) * (1 - t);").arg(f0, d, N(P.rot));
+    S.op = QStringLiteral("return %1 * pSmooth(pSeg(f, %2, %2 + %3));").arg(N(P.op), f0, d);
+}
+void genShockwavePulse(const LayerExprParams& P, LayerExprScripts& S)
+{
+    const auto f0 = N(P.winF0()), d = N(P.D);
+    S.scaleX = QStringLiteral("var t = pSeg(f, %1, %1 + %2); return %3 * (0.2 + 0.8 * (1 + 0.4 * Math.sin(t * Math.PI) * Math.exp(-2 * t)));").arg(f0, d, N(P.sx));
+    S.scaleY = QStringLiteral("var t = pSeg(f, %1, %1 + %2); return %3 * (0.2 + 0.8 * (1 + 0.4 * Math.sin(t * Math.PI) * Math.exp(-2 * t)));").arg(f0, d, N(P.sy));
+    S.op = QStringLiteral("return %1 * pSmooth(pSeg(f, %2, %2 + %3));").arg(N(P.op), f0, N(qMax(1., P.D / 3.)));
+}
+void genSpringPop(const LayerExprParams& P, LayerExprScripts& S)
+{
+    const auto f0 = N(P.winF0()), d = N(P.D);
+    S.scaleX = QStringLiteral("var t = pSeg(f, %1, %1 + %2); return %3 * (1 - Math.pow(2, -10 * t) * Math.sin((10 * t - 0.75) * 2 * Math.PI / 3));").arg(f0, d, N(P.sx));
+    S.scaleY = QStringLiteral("var t = pSeg(f, %1, %1 + %2); return %3 * (1 - Math.pow(2, -10 * t) * Math.sin((10 * t - 0.75) * 2 * Math.PI / 3));").arg(f0, d, N(P.sy));
+    S.op = QStringLiteral("return %1 * pSmooth(pSeg(f, %2, %2 + %3));").arg(N(P.op), f0, N(qMax(1., P.D / 4.)));
+}
+void genWhipSnap(const LayerExprParams& P, LayerExprScripts& S)
+{
+    const auto f0 = N(P.winF0()), d = N(P.D);
+    S.shearX = QStringLiteral("var t = pSeg(f, %1, %1 + %2); return %3 + 0.6 * (1 - t) * Math.cos(t * 12) * Math.exp(-3 * t);").arg(f0, d, N(P.shx));
+    S.posX = QStringLiteral("return %1 - 120 * (1 - pSmooth(pSeg(f, %2, %2 + %3)));").arg(N(P.px), f0, d);
+    S.op = QStringLiteral("return %1 * pSmooth(pSeg(f, %2, %2 + %3));").arg(N(P.op), f0, d);
+}
+void genAnvilCrash(const LayerExprParams& P, LayerExprScripts& S)
+{
+    const auto f0 = N(P.winF0()), d = N(P.D);
+    S.posY = QStringLiteral("var t = pSeg(f, %1, %1 + %2); return %3 - 300 * Math.pow(1 - t, 4);").arg(f0, d, N(P.py));
+    S.scaleY = QStringLiteral("var t = pSeg(f, %1, %1 + %2); return %3 * (1 - 0.35 * Math.sin(t * 16) * Math.exp(-4 * t));").arg(f0, d, N(P.sy));
+    S.scaleX = QStringLiteral("var t = pSeg(f, %1, %1 + %2); return %3 * (1 + 0.35 * Math.sin(t * 16) * Math.exp(-4 * t));").arg(f0, d, N(P.sx));
+    S.op = QStringLiteral("return %1 * pSmooth(pSeg(f, %2, %2 + %3));").arg(N(P.op), f0, N(qMax(1., P.D / 4.)));
+}
+
+// ---------------- UI Transitions & Loops Extensions
+void genSheetSlideUpIn(const LayerExprParams& P, LayerExprScripts& S)
+{
+    const auto f0 = N(P.winF0()), d = N(P.D);
+    S.posY = QStringLiteral("return %1 + %2 * (1 - pSmooth(pSeg(f, %3, %3 + %4)));").arg(N(P.py), N(P.ch / 2 + P.bh), f0, d);
+    S.op = QStringLiteral("return %1 * pSmooth(pSeg(f, %2, %2 + %3));").arg(N(P.op), f0, d);
+}
+void genSheetSlideUpOut(const LayerExprParams& P, LayerExprScripts& S)
+{
+    const auto f0 = N(P.winF0()), d = N(P.D);
+    S.posY = QStringLiteral("return %1 + %2 * pSmooth(pSeg(f, %3, %3 + %4));").arg(N(P.py), N(P.ch / 2 + P.bh), f0, d);
+    S.op = QStringLiteral("return %1 * (1 - pSmooth(pSeg(f, %2, %2 + %3)));").arg(N(P.op), f0, d);
+}
+void genSheetSlideDownIn(const LayerExprParams& P, LayerExprScripts& S)
+{
+    const auto f0 = N(P.winF0()), d = N(P.D);
+    S.posY = QStringLiteral("return %1 - %2 * (1 - pSmooth(pSeg(f, %3, %3 + %4)));").arg(N(P.py), N(P.ch / 2 + P.bh), f0, d);
+    S.op = QStringLiteral("return %1 * pSmooth(pSeg(f, %2, %2 + %3));").arg(N(P.op), f0, d);
+}
+void genSheetSlideDownOut(const LayerExprParams& P, LayerExprScripts& S)
+{
+    const auto f0 = N(P.winF0()), d = N(P.D);
+    S.posY = QStringLiteral("return %1 - %2 * pSmooth(pSeg(f, %3, %3 + %4));").arg(N(P.py), N(P.ch / 2 + P.bh), f0, d);
+    S.op = QStringLiteral("return %1 * (1 - pSmooth(pSeg(f, %2, %2 + %3)));").arg(N(P.op), f0, d);
+}
+void genSheetSlideLeftIn(const LayerExprParams& P, LayerExprScripts& S)
+{
+    const auto f0 = N(P.winF0()), d = N(P.D);
+    S.posX = QStringLiteral("return %1 - %2 * (1 - pSmooth(pSeg(f, %3, %3 + %4)));").arg(N(P.px), N(P.cw / 2 + P.bw), f0, d);
+    S.op = QStringLiteral("return %1 * pSmooth(pSeg(f, %2, %2 + %3));").arg(N(P.op), f0, d);
+}
+void genSheetSlideLeftOut(const LayerExprParams& P, LayerExprScripts& S)
+{
+    const auto f0 = N(P.winF0()), d = N(P.D);
+    S.posX = QStringLiteral("return %1 - %2 * pSmooth(pSeg(f, %3, %3 + %4));").arg(N(P.px), N(P.cw / 2 + P.bw), f0, d);
+    S.op = QStringLiteral("return %1 * (1 - pSmooth(pSeg(f, %2, %2 + %3)));").arg(N(P.op), f0, d);
+}
+void genSheetSlideRightIn(const LayerExprParams& P, LayerExprScripts& S)
+{
+    const auto f0 = N(P.winF0()), d = N(P.D);
+    S.posX = QStringLiteral("return %1 + %2 * (1 - pSmooth(pSeg(f, %3, %3 + %4)));").arg(N(P.px), N(P.cw / 2 + P.bw), f0, d);
+    S.op = QStringLiteral("return %1 * pSmooth(pSeg(f, %2, %2 + %3));").arg(N(P.op), f0, d);
+}
+void genSheetSlideRightOut(const LayerExprParams& P, LayerExprScripts& S)
+{
+    const auto f0 = N(P.winF0()), d = N(P.D);
+    S.posX = QStringLiteral("return %1 + %2 * pSmooth(pSeg(f, %3, %3 + %4));").arg(N(P.px), N(P.cw / 2 + P.bw), f0, d);
+    S.op = QStringLiteral("return %1 * (1 - pSmooth(pSeg(f, %2, %2 + %3)));").arg(N(P.op), f0, d);
+}
+void genIrisZoomPop(const LayerExprParams& P, LayerExprScripts& S)
+{
+    const auto f0 = N(P.winF0()), d = N(P.D);
+    S.scaleX = QStringLiteral("return %1 * (0.05 + 0.95 * pSmooth(pSeg(f, %2, %2 + %3)));").arg(N(P.sx), f0, d);
+    S.scaleY = QStringLiteral("return %1 * (0.05 + 0.95 * pSmooth(pSeg(f, %2, %2 + %3)));").arg(N(P.sy), f0, d);
+    S.rot = QStringLiteral("return %1 + 45 * (1 - pSmooth(pSeg(f, %2, %2 + %3)));").arg(N(P.rot), f0, d);
+    S.op = QStringLiteral("return %1 * pSmooth(pSeg(f, %2, %2 + %3));").arg(N(P.op), f0, d);
+}
+void genGlitchShake(const LayerExprParams& P, LayerExprScripts& S)
+{
+    const auto f0 = N(P.winF0()), d = N(P.D);
+    S.posX = QStringLiteral("if (f < %1) return %2; var u = pPh(f, %1, %3); return %2 + (Math.sin(u * 50) > 0.3 ? 6 * Math.sin(u * 80) : 0);").arg(f0, N(P.px), d);
+    S.posY = QStringLiteral("if (f < %1) return %2; var u = pPh(f, %1, %3); return %2 + (Math.cos(u * 40) > 0.4 ? 4 * Math.cos(u * 60) : 0);").arg(f0, N(P.py), d);
+}
+void genEndlessFloat(const LayerExprParams& P, LayerExprScripts& S)
+{
+    const auto f0 = N(P.winF0()), d = N(P.D);
+    S.posX = QStringLiteral("if (f < %1) return %2; return %2 + 8 * Math.sin(2 * Math.PI * pPh(f, %1, %3));").arg(f0, N(P.px), d);
+    S.posY = QStringLiteral("if (f < %1) return %2; return %2 + 12 * Math.sin(4 * Math.PI * pPh(f, %1, %3));").arg(f0, N(P.py), d);
+}
+void genCompassNeedle(const LayerExprParams& P, LayerExprScripts& S)
+{
+    const auto f0 = N(P.winF0()), d = N(P.D);
+    S.rot = QStringLiteral("if (f < %1) return %2; return %2 + 8 * Math.sin(2 * Math.PI * pPh(f, %1, %3)) * Math.cos(4 * Math.PI * pPh(f, %1, %3));").arg(f0, N(P.rot), d);
+}
+void genTensionVibrate(const LayerExprParams& P, LayerExprScripts& S)
+{
+    const auto f0 = N(P.winF0()), d = N(P.D);
+    S.posX = QStringLiteral("if (f < %1) return %2; return %2 + 2.5 * Math.sin(20 * Math.PI * pPh(f, %1, %3));").arg(f0, N(P.px), d);
+    S.posY = QStringLiteral("if (f < %1) return %2; return %2 + 2.5 * Math.cos(20 * Math.PI * pPh(f, %1, %3));").arg(f0, N(P.py), d);
+}
+void genHeartbeatLayer(const LayerExprParams& P, LayerExprScripts& S)
+{
+    const auto f0 = N(P.winF0()), d = N(P.D);
+    S.scaleX = QStringLiteral("if (f < %1) return %2; var u = pPh(f, %1, %3); var p = (u < 0.2 ? Math.sin(u * 5 * Math.PI) : (u < 0.4 ? 0.6 * Math.sin((u - 0.2) * 5 * Math.PI) : 0)); return %2 * (1 + 0.15 * p);").arg(f0, N(P.sx), d);
+    S.scaleY = QStringLiteral("if (f < %1) return %2; var u = pPh(f, %1, %3); var p = (u < 0.2 ? Math.sin(u * 5 * Math.PI) : (u < 0.4 ? 0.6 * Math.sin((u - 0.2) * 5 * Math.PI) : 0)); return %2 * (1 + 0.15 * p);").arg(f0, N(P.sy), d);
+}
+
 struct LayerPresetBuilder {
     LayerAnimPreset p;
     LayerPresetBuilder& in() { p.category = 0; return *this; }
     LayerPresetBuilder& out() { p.category = 1; return *this; }
     LayerPresetBuilder& loop() { p.category = 2; return *this; }
+    LayerPresetBuilder& tag(const QString& t) { p.tag = t; return *this; }
     LayerPresetBuilder& dur(const qreal d) { p.duration = d; return *this; }
     LayerPresetBuilder& outGen(
             void (*og)(const LayerExprParams&, LayerExprScripts&))
@@ -330,57 +939,236 @@ void ensurePresets()
         return b;
     };
 
-    // ---- one-shot (in / out) ----
+    // =========================================================================
+    // 1. 图层入出场动画（Layer In / Out）
+    // =========================================================================
     addPreset(gPresets, B("l-fade", QString::fromUtf8("淡入淡出"),
                           QString::fromUtf8("入：渐渐显现；出：渐渐消失"))
-              .in().dur(0.8).genExpr(&genFadeIn)
+              .in().tag("inout").dur(0.8).genExpr(&genFadeIn)
               .outGen(&genFadeOut).p);
     addPreset(gPresets, B("l-slide-l", QString::fromUtf8("左侧划动"),
                           QString::fromUtf8("入：从画布左外滑入；出：滑出画布左侧"))
-              .in().dur(0.8).genExpr(&genSlideInLeft)
+              .in().tag("inout").dur(0.8).genExpr(&genSlideInLeft)
               .outGen(&genSlideOutLeft).p);
     addPreset(gPresets, B("l-slide-r", QString::fromUtf8("右侧划动"),
                           QString::fromUtf8("入：从画布右外滑入；出：滑出画布右侧"))
-              .in().dur(0.8).genExpr(&genSlideInRight)
+              .in().tag("inout").dur(0.8).genExpr(&genSlideInRight)
               .outGen(&genSlideOutRight).p);
+    addPreset(gPresets, B("l-slide-up", QString::fromUtf8("底部滑入"),
+                          QString::fromUtf8("入：从下方滑入；出：向上方滑出"))
+              .in().tag("inout").dur(0.8).genExpr(&genSlideInUp)
+              .outGen(&genSlideOutUp).p);
+    addPreset(gPresets, B("l-slide-down", QString::fromUtf8("顶部滑入"),
+                          QString::fromUtf8("入：从上方滑入；出：向下方滑出"))
+              .in().tag("inout").dur(0.8).genExpr(&genSlideInDown)
+              .outGen(&genSlideOutDown).p);
     addPreset(gPresets, B("l-zoom", QString::fromUtf8("弹性缩放"),
                           QString::fromUtf8("入：放大弹出回弹稳定；出：缩小淡出"))
-              .in().dur(0.7).genExpr(&genZoomIn)
+              .in().tag("inout").dur(0.7).genExpr(&genZoomIn)
               .outGen(&genZoomOut).p);
-    addPreset(gPresets, B("l-spin", QString::fromUtf8("旋转"),
+    addPreset(gPresets, B("l-zoom-far", QString::fromUtf8("远景冲入"),
+                          QString::fromUtf8("入：远景高倍俯冲冲入；出：冲向镜头前淡出"))
+              .in().tag("inout").dur(0.9).genExpr(&genZoomFarIn)
+              .outGen(&genZoomFarOut).p);
+    addPreset(gPresets, B("l-elastic-scale", QString::fromUtf8("果冻膨胀"),
+                          QString::fromUtf8("入：多段果冻弹性膨胀回弹落定"))
+              .in().tag("inout").dur(0.8).genExpr(&genElasticScale)
+              .outGen(&genZoomOut).p);
+    addPreset(gPresets, B("l-spin", QString::fromUtf8("旋转进入"),
                           QString::fromUtf8("入：旋转半圈淡入落定；出：旋转缩小消失"))
-              .in().dur(0.9).genExpr(&genSpinIn)
+              .in().tag("inout").dur(0.9).genExpr(&genSpinIn)
               .outGen(&genSpinOut).p);
-    addPreset(gPresets, B("l-pop", QString::fromUtf8("弹出"),
+    addPreset(gPresets, B("l-swing", QString::fromUtf8("秋千摆动"),
+                          QString::fromUtf8("入：单侧悬挂秋千阻尼摇荡落定；出：大角度荡出"))
+              .in().tag("inout").dur(1.1).genExpr(&genSwingIn)
+              .outGen(&genSwingOut).p);
+    addPreset(gPresets, B("l-stamp", QString::fromUtf8("印章重击"),
+                          QString::fromUtf8("入：自高处印章重击砸落带有触地微震"))
+              .in().tag("inout").dur(0.6).genExpr(&genStampIn).p);
+    addPreset(gPresets, B("l-pop", QString::fromUtf8("快速弹出"),
                           QString::fromUtf8("快速弹出并轻微回弹（仅入点）"))
-              .in().dur(0.5).genExpr(&genPopIn).p);
+              .in().tag("inout").dur(0.5).genExpr(&genPopIn).p);
     addPreset(gPresets, B("l-drop", QString::fromUtf8("落下弹跳"),
                           QString::fromUtf8("从上方落下触地弹两下（仅入点）"))
-              .in().dur(1.0).genExpr(&genDropBounce).p);
-    addPreset(gPresets, B("l-sink", QString::fromUtf8("下沉"),
-                          QString::fromUtf8("下沉并淡出（仅出点）"))
-              .in().dur(0.9).outGen(&genSinkOut).p);
+              .in().tag("inout").dur(1.0).genExpr(&genDropBounce).p);
+    addPreset(gPresets, B("l-sink", QString::fromUtf8("下沉隐退"),
+                          QString::fromUtf8("入：从底部浮上站定；出：下沉并淡出"))
+              .in().tag("inout").dur(0.9).genExpr(&genSinkIn)
+              .outGen(&genSinkOut).p);
+    addPreset(gPresets, B("l-expand-h", QString::fromUtf8("水平百叶"),
+                          QString::fromUtf8("入：横向百叶拉开展开；出：横向收拢"))
+              .in().tag("inout").dur(0.8).genExpr(&genExpandHIn)
+              .outGen(&genExpandHOut).p);
+    addPreset(gPresets, B("l-expand-v", QString::fromUtf8("垂直拉帘"),
+                          QString::fromUtf8("入：垂直拉帘纵向撑开；出：纵向折叠收起"))
+              .in().tag("inout").dur(0.8).genExpr(&genExpandVIn)
+              .outGen(&genExpandVOut).p);
+    addPreset(gPresets, B("l-skew-slide", QString::fromUtf8("左斜切入"),
+                          QString::fromUtf8("入：动感斜切姿态从左滑入；出：向左滑离"))
+              .in().tag("inout").dur(0.8).genExpr(&genSkewSlideInLeft)
+              .outGen(&genSkewSlideOutLeft).p);
+    addPreset(gPresets, B("l-skew-slide-r", QString::fromUtf8("右斜切入"),
+                          QString::fromUtf8("入：动感斜切姿态从右滑入；出：向右滑离"))
+              .in().tag("inout").dur(0.8).genExpr(&genSkewSlideInRight)
+              .outGen(&genSkewSlideOutRight).p);
 
-    // ---- loops (infinite: the expression keeps evaluating for any
-    // frame past the window start) ----
-    addPreset(gPresets, B("l-shake", QString::fromUtf8("抖动"),
+    // =========================================================================
+    // 2. 2.5D 空间与翻折（3D Space Transitions）
+    // =========================================================================
+    addPreset(gPresets, B("l-flip-x", QString::fromUtf8("3D水平翻转"),
+                QString::fromUtf8("入：围绕水平轴翻折 90 度入场；出：翻折退场"))
+              .in().tag("3d").dur(0.85).genExpr(&genFlipXIn)
+              .outGen(&genFlipXOut).p);
+    addPreset(gPresets, B("l-flip-y", QString::fromUtf8("3D垂直翻折"),
+                QString::fromUtf8("入：围绕垂直轴如翻书般 90 度展开；出：翻折收起"))
+              .in().tag("3d").dur(0.85).genExpr(&genFlipYIn)
+              .outGen(&genFlipYOut).p);
+    addPreset(gPresets, B("l-fly-in-3d", QString::fromUtf8("3D穿梭飞入"),
+                QString::fromUtf8("入：从 2.5D 深度空间高速冲向镜头；出：飞向景深处"))
+              .in().tag("3d").dur(1.0).genExpr(&genFlyIn3D)
+              .outGen(&genFlyOut3D).p);
+
+    // =========================================================================
+    // 3. 图层循环动效（Layer Loops）
+    // =========================================================================
+    addPreset(gPresets, B("l-shake", QString::fromUtf8("剧烈抖动"),
                           QString::fromUtf8("高频左右小幅抖动"))
-              .loop().dur(0.5).genExpr(&genShake).p);
-    addPreset(gPresets, B("l-sway", QString::fromUtf8("摇摆"),
+              .loop().tag("loop").dur(0.5).genExpr(&genShake).p);
+    addPreset(gPresets, B("l-sway", QString::fromUtf8("左右摇摆"),
                           QString::fromUtf8("像钟摆一样左右摇摆"))
-              .loop().dur(1.2).genExpr(&genSway).p);
-    addPreset(gPresets, B("l-hop", QString::fromUtf8("蹦跳"),
+              .loop().tag("loop").dur(1.2).genExpr(&genSway).p);
+    addPreset(gPresets, B("l-hop", QString::fromUtf8("原地蹦跳"),
                           QString::fromUtf8("原地起跳两次，落地压扁"))
-              .loop().dur(1.2).genExpr(&genHop).p);
+              .loop().tag("loop").dur(1.2).genExpr(&genHop).p);
     addPreset(gPresets, B("l-squash", QString::fromUtf8("弹性拉伸蹦跶"),
                           QString::fromUtf8("原地压扁拉伸交替小幅蹦跶"))
-              .loop().dur(0.9).genExpr(&genSquashStretch).p);
-    addPreset(gPresets, B("l-breathe", QString::fromUtf8("呼吸"),
+              .loop().tag("loop").dur(0.9).genExpr(&genSquashStretch).p);
+    addPreset(gPresets, B("l-breathe", QString::fromUtf8("平稳呼吸"),
                           QString::fromUtf8("缓慢缩放呼吸起伏"))
-              .loop().dur(1.6).genExpr(&genBreathe).p);
-    addPreset(gPresets, B("l-wobble", QString::fromUtf8("晃动"),
+              .loop().tag("loop").dur(1.6).genExpr(&genBreathe).p);
+    addPreset(gPresets, B("l-wobble", QString::fromUtf8("综合晃动"),
                           QString::fromUtf8("左右平移加轻微旋转晃动"))
-              .loop().dur(1.0).genExpr(&genWobble).p);
+              .loop().tag("loop").dur(1.0).genExpr(&genWobble).p);
+    addPreset(gPresets, B("l-float", QString::fromUtf8("悠闲漂浮"),
+                          QString::fromUtf8("如水中气泡或空间失重般上下轻浮"))
+              .loop().tag("loop").dur(2.2).genExpr(&genFloat).p);
+    addPreset(gPresets, B("l-spin-loop", QString::fromUtf8("匀速自转"),
+                          QString::fromUtf8("围绕中心点持续 360 度匀速旋转"))
+              .loop().tag("loop").dur(2.5).genExpr(&genSpinLoop).p);
+    addPreset(gPresets, B("l-pulse-scale", QString::fromUtf8("节拍脉冲"),
+                          QString::fromUtf8("跟随音乐节拍般周期性重音缩放"))
+              .loop().tag("loop").dur(0.8).genExpr(&genPulseScale).p);
+    addPreset(gPresets, B("l-pendulum", QString::fromUtf8("物理钟摆"),
+                          QString::fromUtf8("大振幅自然正弦钟摆摇荡"))
+              .loop().tag("loop").dur(1.6).genExpr(&genPendulum).p);
+    addPreset(gPresets, B("l-jiggle", QString::fromUtf8("果冻微颤"),
+                          QString::fromUtf8("X 与 Y 轴反相微震果冻颤动"))
+              .loop().tag("loop").dur(0.7).genExpr(&genJiggle).p);
+    addPreset(gPresets, B("l-orbit-3d", QString::fromUtf8("3D空间视差"),
+                          QString::fromUtf8("2.5D 透视水平与垂直微倾斜悬浮"))
+              .loop().tag("3d").dur(2.6).genExpr(&genOrbit3D).p);
+
+    // =========================================================================
+    // 4. 新增 2.5D 空间与透视（3D Space Transitions Expanded）
+    // =========================================================================
+    addPreset(gPresets, B("l-door-open-l", QString::fromUtf8("3D门页左开"),
+                          QString::fromUtf8("入：以左侧边框为轴如开门般 90 度展开；出：向内关门退场"))
+              .in().tag("3d").dur(0.85).genExpr(&genDoorOpenLIn).outGen(&genDoorOpenLOut).p);
+    addPreset(gPresets, B("l-door-open-r", QString::fromUtf8("3D门页右开"),
+                          QString::fromUtf8("入：以右侧边框为轴如开门般 90 度展开；出：向内关门退场"))
+              .in().tag("3d").dur(0.85).genExpr(&genDoorOpenRIn).outGen(&genDoorOpenROut).p);
+    addPreset(gPresets, B("l-dive-3d", QString::fromUtf8("3D俯冲深潜"),
+                          QString::fromUtf8("入：俯角 60 度伴随 Z 轴自深空俯冲拉平；出：俯冲冲向深景"))
+              .in().tag("3d").dur(0.95).genExpr(&genDive3DIn).outGen(&genDive3DOut).p);
+    addPreset(gPresets, B("l-climb-3d", QString::fromUtf8("3D昂首仰冲"),
+                          QString::fromUtf8("入：仰角 60 度伴随 Z 轴仰冲归位；出：仰角飞离镜头"))
+              .in().tag("3d").dur(0.95).genExpr(&genClimb3DIn).outGen(&genClimb3DOut).p);
+    addPreset(gPresets, B("l-axial-roll", QString::fromUtf8("3D轴向翻转"),
+                          QString::fromUtf8("入：双轴 180 度立体翻折展开；出：双轴翻折淡出"))
+              .in().tag("3d").dur(0.9).genExpr(&genAxialRollIn).outGen(&genAxialRollOut).p);
+    addPreset(gPresets, B("l-tilt-sway", QString::fromUtf8("3D视差微倾"),
+                          QString::fromUtf8("入：对角空间轻微倾斜摆正；出：向对角空间倾斜淡出"))
+              .in().tag("3d").dur(0.8).genExpr(&genTiltSwayIn).outGen(&genTiltSwayOut).p);
+    addPreset(gPresets, B("l-isometric-drop", QString::fromUtf8("等轴测降落"),
+                          QString::fromUtf8("保持等轴测 3D 俯视视角从高空砸落定格"))
+              .in().tag("3d").dur(0.85).genExpr(&genIsometricDrop).p);
+    addPreset(gPresets, B("l-depth-zoom-burst", QString::fromUtf8("景深爆发突进"),
+                          QString::fromUtf8("入：自极远 1500px 深度爆冲入画；出：冲破镜头飞散"))
+              .in().tag("3d").dur(0.8).genExpr(&genDepthZoomBurstIn).outGen(&genDepthZoomBurstOut).p);
+    addPreset(gPresets, B("l-card-unfold-3d", QString::fromUtf8("3D折纸展开"),
+                          QString::fromUtf8("入：折叠卡片多轴连续舒展铺平；出：翻折闭合"))
+              .in().tag("3d").dur(0.9).genExpr(&genCardUnfold3DIn).outGen(&genCardUnfold3DOut).p);
+    addPreset(gPresets, B("l-orbit-helix", QString::fromUtf8("3D双轴螺旋"),
+                          QString::fromUtf8("在 2.5D 深度空间沿立体双螺旋轨道巡游"))
+              .loop().tag("3d").dur(2.8).genExpr(&genOrbitHelix).p);
+
+    // =========================================================================
+    // 5. 新增物理动力学与重击模拟（Physical Dynamics Expanded）
+    // =========================================================================
+    addPreset(gPresets, B("l-jelly-wobble", QString::fromUtf8("多段果冻回弹"),
+                QString::fromUtf8("入场后多段果冻流体弹性震颤平复"))
+              .in().tag("inout").dur(0.9).genExpr(&genJellyWobble).p);
+    addPreset(gPresets, B("l-rubber-bounce", QString::fromUtf8("高弹胶皮弹跳"),
+                QString::fromUtf8("重力砸落并带有胶皮高弹形变跳跃"))
+              .in().tag("inout").dur(1.0).genExpr(&genRubberBounce).p);
+    addPreset(gPresets, B("l-heavy-stamp-jitter", QString::fromUtf8("重锤砸地微震"),
+                QString::fromUtf8("超重物坠地砸出地面高频震颤反馈"))
+              .in().tag("inout").dur(0.7).genExpr(&genHeavyStampJitter).p);
+    addPreset(gPresets, B("l-magnetic-snap", QString::fromUtf8("磁吸瞬切归位"),
+                QString::fromUtf8("强磁力瞬时抽吸归位并伴随阻尼微颤"))
+              .in().tag("inout").dur(0.6).genExpr(&genMagneticSnap).p);
+    addPreset(gPresets, B("l-pendulum-settle", QString::fromUtf8("阻尼钟摆停定"),
+                QString::fromUtf8("大角度正弦自由落体摇荡衰减直至停正"))
+              .in().tag("inout").dur(1.2).genExpr(&genPendulumSettle).p);
+    addPreset(gPresets, B("l-balloon-float", QString::fromUtf8("气球失重升腾"),
+                QString::fromUtf8("轻气球般自下方轻柔升起并伴随左右游荡"))
+              .in().tag("inout").dur(1.1).genExpr(&genBalloonFloat).p);
+    addPreset(gPresets, B("l-shockwave-pulse", QString::fromUtf8("冲击波爆发扩散"),
+                QString::fromUtf8("极小内核瞬间爆裂为超大波纹回弹定格"))
+              .in().tag("inout").dur(0.75).genExpr(&genShockwavePulse).p);
+    addPreset(gPresets, B("l-spring-pop", QString::fromUtf8("弹簧高弹弹出"),
+                QString::fromUtf8("弹簧装置高爆发弹出谐振"))
+              .in().tag("inout").dur(0.85).genExpr(&genSpringPop).p);
+    addPreset(gPresets, B("l-whip-snap", QString::fromUtf8("长鞭疾抽归位"),
+                QString::fromUtf8("长鞭高速抽打带有剪切角瞬时甩正"))
+              .in().tag("inout").dur(0.65).genExpr(&genWhipSnap).p);
+    addPreset(gPresets, B("l-anvil-crash", QString::fromUtf8("铁砧重扣大地"),
+                QString::fromUtf8("极速坠地并发生剧烈横向挤压与纵向回弹"))
+              .in().tag("inout").dur(0.75).genExpr(&genAnvilCrash).p);
+
+    // =========================================================================
+    // 6. 新增 UI 界面转场与持续循环（UI Transitions & Loops Expanded）
+    // =========================================================================
+    addPreset(gPresets, B("l-sheet-slide-up", QString::fromUtf8("底栏抽屉升起"),
+                QString::fromUtf8("入：自底部抽屉轻柔升起；出：滑向底部收起"))
+              .in().tag("inout").dur(0.75).genExpr(&genSheetSlideUpIn).outGen(&genSheetSlideUpOut).p);
+    addPreset(gPresets, B("l-sheet-slide-down", QString::fromUtf8("顶栏抽屉垂落"),
+                QString::fromUtf8("入：自顶部抽屉轻柔垂落；出：滑向顶部收起"))
+              .in().tag("inout").dur(0.75).genExpr(&genSheetSlideDownIn).outGen(&genSheetSlideDownOut).p);
+    addPreset(gPresets, B("l-sheet-slide-left", QString::fromUtf8("侧栏抽屉左入"),
+                QString::fromUtf8("入：自左边缘侧滑展开；出：滑回左边缘"))
+              .in().tag("inout").dur(0.75).genExpr(&genSheetSlideLeftIn).outGen(&genSheetSlideLeftOut).p);
+    addPreset(gPresets, B("l-sheet-slide-right", QString::fromUtf8("侧栏抽屉右入"),
+                QString::fromUtf8("入：自右边缘侧滑展开；出：滑回右边缘"))
+              .in().tag("inout").dur(0.75).genExpr(&genSheetSlideRightIn).outGen(&genSheetSlideRightOut).p);
+    addPreset(gPresets, B("l-iris-zoom-pop", QString::fromUtf8("快门光圈放大"),
+                QString::fromUtf8("伴随轻微旋转如同快门光圈瞬时开合就位"))
+              .in().tag("inout").dur(0.7).genExpr(&genIrisZoomPop).p);
+    addPreset(gPresets, B("l-glitch-shake", QString::fromUtf8("故障断电震颤"),
+                QString::fromUtf8("高频离散跳变的故障电流抖动循环"))
+              .loop().tag("loop").dur(0.8).genExpr(&genGlitchShake).p);
+    addPreset(gPresets, B("l-endless-float", QString::fromUtf8("深空漫游浮沉"),
+                QString::fromUtf8("利萨如图形双轴无重力平滑沉浮漂移"))
+              .loop().tag("loop").dur(3.0).genExpr(&genEndlessFloat).p);
+    addPreset(gPresets, B("l-compass-needle", QString::fromUtf8("罗盘指针微摇"),
+                QString::fromUtf8("航海罗盘磁针般自然左右轻晃"))
+              .loop().tag("loop").dur(2.0).genExpr(&genCompassNeedle).p);
+    addPreset(gPresets, B("l-tension-vibrate", QString::fromUtf8("高张力微震"),
+                QString::fromUtf8("紧绷琴弦般的超高频极微幅颤动"))
+              .loop().tag("loop").dur(0.5).genExpr(&genTensionVibrate).p);
+    addPreset(gPresets, B("l-heartbeat-layer", QString::fromUtf8("图层心跳重音"),
+                QString::fromUtf8("模拟心脏舒张收缩的双重节拍缩放脉动"))
+              .loop().tag("loop").dur(1.0).genExpr(&genHeartbeatLayer).p);
 }
 }
 
@@ -416,11 +1204,10 @@ void apply(BoundingBox* const box,
            const qreal canvasH,
            const bool action)
 {
-    const auto gen = preset.gen;
-    if (!box || !gen) { return; }
+    if (!box || (!preset.gen && !preset.outGen)) { return; }
     // box transform animators are AdvancedTransformAnimator-based
     // (BoxTransformAnimator); expressions go on the qreal
-    // sub-animators (pos/scale x/y, rotation, opacity)
+    // sub-animators (pos/scale x/y, rotation, opacity, shear, 3D)
     const auto t = dynamic_cast<AdvancedTransformAnimator*>(
                 box->getTransformAnimator());
     if (!t) { return; }
@@ -437,19 +1224,30 @@ void apply(BoundingBox* const box,
     const auto scale = t->getScaleAnimator();
     const auto rotA = t->getRotAnimator();
     const auto opA = t->getOpacityAnimator();
+    const auto shear = t->getShearAnimator();
+    const auto rotX = t->getRotXAnimator();
+    const auto rotY = t->getRotYAnimator();
+    const auto zPos = t->getZPosAnimator();
+
     const QPointF p0 = pos ? pos->getBaseValue() : QPointF();
     const QPointF s0 = scale ? scale->getBaseValue() : QPointF(1, 1);
+    const QPointF sh0 = shear ? shear->getBaseValue() : QPointF();
     P.px = p0.x();
     P.py = p0.y();
     P.sx = s0.x();
     P.sy = s0.y();
     P.rot = rotA ? rotA->getCurrentBaseValue() : 0.;
     P.op = opA ? opA->getCurrentBaseValue() : 100.;
+    P.shx = sh0.x();
+    P.shy = sh0.y();
+    P.rx = rotX ? rotX->getCurrentBaseValue() : 0.;
+    P.ry = rotY ? rotY->getCurrentBaseValue() : 0.;
+    P.pz = zPos ? zPos->getCurrentBaseValue() : 0.;
 
     LayerExprScripts inS, outS;
-    if (inStartFrame >= 0) {
+    if (inStartFrame >= 0 && preset.gen) {
         P.inF0 = t->prp_absFrameToRelFrameF(inStartFrame);
-        gen(P, inS);
+        preset.gen(P, inS);
     }
     if (outStartFrame >= 0 && preset.outGen) {
         // generators read the active window via winF0(); hide the
@@ -459,6 +1257,13 @@ void apply(BoundingBox* const box,
         P.outF0 = t->prp_absFrameToRelFrameF(outStartFrame);
         preset.outGen(P, outS);
         P.inF0 = savedInF0;
+    }
+
+    const bool uses3D = (!inS.rotX.isEmpty() || !outS.rotX.isEmpty() ||
+                         !inS.rotY.isEmpty() || !outS.rotY.isEmpty() ||
+                         !inS.posZ.isEmpty() || !outS.posZ.isEmpty());
+    if (uses3D && !t->is3DEnabled()) {
+        t->set3DEnabled(true);
     }
 
     struct T { QrealAnimator* anim; const QString* inSc; const QString* outSc; };
@@ -472,7 +1277,14 @@ void apply(BoundingBox* const box,
             << T{ scale ? scale->getYAnimator() : nullptr,
                   &inS.scaleY, &outS.scaleY }
             << T{ rotA, &inS.rot, &outS.rot }
-            << T{ opA, &inS.op, &outS.op };
+            << T{ opA, &inS.op, &outS.op }
+            << T{ shear ? shear->getXAnimator() : nullptr,
+                  &inS.shearX, &outS.shearX }
+            << T{ shear ? shear->getYAnimator() : nullptr,
+                  &inS.shearY, &outS.shearY }
+            << T{ rotX, &inS.rotX, &outS.rotX }
+            << T{ rotY, &inS.rotY, &outS.rotY }
+            << T{ zPos, &inS.posZ, &outS.posZ };
     for (const auto& tgt : targets) {
         if (!tgt.anim) { continue; }
         const bool hasIn = tgt.inSc && !tgt.inSc->isEmpty();
@@ -524,9 +1336,9 @@ void apply(BoundingBox* const box,
 }
 
 QList<QImage> renderPreviewSequence(BoundingBox* const box,
-                                    const QList<qreal>& frames,
-                                    const QSize& imgSize,
-                                    const QImage& content)
+                                     const QList<qreal>& frames,
+                                     const QSize& imgSize,
+                                     const QImage& content)
 {
     QList<QImage> result;
     if (!box || imgSize.width() < 2 || imgSize.height() < 2) {
@@ -544,10 +1356,17 @@ QList<QImage> renderPreviewSequence(BoundingBox* const box,
     }
     // collect the transformed bounds of every frame first so all
     // frames share one stable fit
-    struct FrameData { QMatrix transform; qreal opacity; SkPath path; };
+    struct FrameData {
+        QMatrix transform;
+        SkMatrix totalTransform;
+        qreal opacity = 100;
+        SkPath path;
+    };
     QList<FrameData> built;
     QRectF unionBounds;
     const auto pathBox = enve_cast<PathBox*>(box);
+    const auto advT = dynamic_cast<AdvancedTransformAnimator*>(
+                box->getTransformAnimator());
     for (const auto relFrame : frames) {
         FrameData fd;
         fd.transform = box->getRelativeTransformAtFrame(relFrame);
@@ -561,8 +1380,12 @@ QList<QImage> renderPreviewSequence(BoundingBox* const box,
             rect.addRoundRect(toSkRect(rel), 8, 8);
             fd.path = rect;
         }
+        fd.totalTransform = toSkMatrix(fd.transform);
+        if (advT && advT->is3DEnabled() && advT->has3DTransformAtFrame(relFrame)) {
+            fd.totalTransform.preConcat(advT->get3DTransformAtFrame(relFrame));
+        }
         SkPath transformed = fd.path;
-        transformed.transform(toSkMatrix(fd.transform));
+        transformed.transform(fd.totalTransform);
         const QRectF b = toQRectF(transformed.computeTightBounds());
         unionBounds = unionBounds.isNull() ? b : unionBounds.united(b);
         built << fd;
@@ -581,9 +1404,9 @@ QList<QImage> renderPreviewSequence(BoundingBox* const box,
         QImage img(imgSize, QImage::Format_ARGB32_Premultiplied);
         img.fill(Qt::transparent);
         const auto info = SkImageInfo::Make(imgSize.width(),
-                                            imgSize.height(),
-                                            kN32_SkColorType,
-                                            kPremul_SkAlphaType);
+                                             imgSize.height(),
+                                             kN32_SkColorType,
+                                             kPremul_SkAlphaType);
         const auto surface = SkSurface::MakeRasterDirect(
                     info, img.bits(),
                     static_cast<size_t>(img.bytesPerLine()));
@@ -595,7 +1418,7 @@ QList<QImage> renderPreviewSequence(BoundingBox* const box,
         canvas->translate(toSkScalar(tx), toSkScalar(ty));
         canvas->scale(toSkScalar(scale), toSkScalar(scale));
         SkPath transformed = fd.path;
-        transformed.transform(toSkMatrix(fd.transform));
+        transformed.transform(fd.totalTransform);
         SkPaint paint;
         paint.setAntiAlias(true);
         paint.setAlphaf(static_cast<float>(fd.opacity/100.));

--- a/src/core/layeranimpresets.h
+++ b/src/core/layeranimpresets.h
@@ -43,6 +43,9 @@ struct CORE_EXPORT LayerExprParams {
     qreal sx = 1, sy = 1;    // rest scale
     qreal rot = 0;           // rest rotation (deg)
     qreal op = 100;          // rest opacity (0..100)
+    qreal shx = 0, shy = 0;  // rest shear
+    qreal rx = 0, ry = 0;    // rest 3D rotX, rotY (deg)
+    qreal pz = 0;            // rest 3D z-position
     qreal winF0() const { return inF0 >= 0 ? inF0 : outF0; }
 };
 
@@ -50,6 +53,8 @@ struct CORE_EXPORT LayerExprParams {
 // frame); empty strings mean the preset does not touch that animator
 struct CORE_EXPORT LayerExprScripts {
     QString posX, posY, scaleX, scaleY, rot, op;
+    QString shearX, shearY;
+    QString rotX, rotY, posZ;
 };
 
 struct CORE_EXPORT LayerAnimPreset {
@@ -58,6 +63,7 @@ struct CORE_EXPORT LayerAnimPreset {
     QString desc;
     int category = 0;   // 0 = one-shot (in / out), 2 = loop
     qreal duration = 1.0;   // seconds (one cycle for loops)
+    QString tag;        // "inout", "loop", "3d"
 
     // generates the entrance / exit scripts for the animators the
     // preset touches; the active window comes from winF0()

--- a/src/core/textanimpresets.cpp
+++ b/src/core/textanimpresets.cpp
@@ -62,12 +62,21 @@ struct PresetBuilder {
     PresetBuilder& letters() { p.fragment = 0; return *this; }
     PresetBuilder& words() { p.fragment = 1; return *this; }
     PresetBuilder& lines() { p.fragment = 2; return *this; }
+    PresetBuilder& tag(const QString& t) { p.tag = t; return *this; }
     PresetBuilder& pos(const qreal x, const qreal y)
     { p.posX = x; p.posY = y; return *this; }
     PresetBuilder& rot(const qreal r)
     { p.rot = r; return *this; }
     PresetBuilder& scale(const qreal s)
     { p.scaleX = s; p.scaleY = s; return *this; }
+    PresetBuilder& scaleX(const qreal sx)
+    { p.scaleX = sx; return *this; }
+    PresetBuilder& scaleY(const qreal sy)
+    { p.scaleY = sy; return *this; }
+    PresetBuilder& scaleXY(const qreal sx, const qreal sy)
+    { p.scaleX = sx; p.scaleY = sy; return *this; }
+    PresetBuilder& shear(const qreal sx, const qreal sy = 0)
+    { p.shearX = sx; p.shearY = sy; return *this; }
     PresetBuilder& opacity(const qreal o)
     { p.opacity = o; return *this; }
     PresetBuilder& center()
@@ -78,6 +87,10 @@ struct PresetBuilder {
     { p.softness = s; return *this; }
     PresetBuilder& rtl()
     { p.direction = TextAnimDirection::rightToLeft; return *this; }
+    PresetBuilder& easing(const TextEasing e)
+    { p.easing = e; return *this; }
+    PresetBuilder& stagger(const qreal s)
+    { p.staggerPercent = s; return *this; }
     PresetBuilder& wave(const int cycles, const qreal periodSec)
     { p.kind = TextAnim::wave; p.waveCycles = cycles; p.waveTime = periodSec; return *this; }
     PresetBuilder& pulse(const qreal peak = 1.)
@@ -96,64 +109,647 @@ void ensurePresets()
         return b;
     };
 
-    // ---- one-shot (applied as entrance or exit) ----
-    addPreset(B("rise", QString::fromUtf8("上浮"),
-                QString::fromUtf8("入：文字从下方依次浮起；出：上飘并淡出"))
-              .in().letters().pos(0, 60).opacity(0).dur(1.2).soft(0.35).p);
-    addPreset(B("fade", QString::fromUtf8("淡入淡出"),
-                QString::fromUtf8("入：按顺序依次显现；出：依次消失"))
-              .in().letters().opacity(0).dur(1.0).soft(0.3).p);
-    addPreset(B("slide-l", QString::fromUtf8("左侧划动"),
-                QString::fromUtf8("入：从左滑入；出：向左滑出"))
-              .in().letters().pos(-90, 0).dur(1.0).soft(0.3).p);
-    addPreset(B("slide-r", QString::fromUtf8("右侧划动"),
-                QString::fromUtf8("入：从右滑入；出：向右滑出"))
-              .in().letters().pos(90, 0).dur(1.0).soft(0.3).p);
-    addPreset(B("zoom", QString::fromUtf8("缩放"),
-                QString::fromUtf8("入：由小放大弹出；出：缩小并淡出"))
-              .in().letters().scale(0).center().dur(1.0).soft(0.3).p);
-    addPreset(B("spin", QString::fromUtf8("旋转"),
-                QString::fromUtf8("入：旋转缩放飞入；出：旋转缩小消失"))
-              .in().letters().rot(120).scale(0.2).opacity(0).center().dur(1.2).soft(0.3).p);
-    addPreset(B("typewriter", QString::fromUtf8("打字机"),
-                QString::fromUtf8("入：逐字蹦出；出：逐字回删"))
-              .in().letters().opacity(0).dur(1.6).soft(0.08).p);
-    addPreset(B("drop", QString::fromUtf8("上方落下"),
-                QString::fromUtf8("入：从上方逐字落下；出：向上飞离"))
-              .in().letters().pos(0, -70).dur(1.0).soft(0.3).p);
-    addPreset(B("word-rise", QString::fromUtf8("逐词上浮"),
-                QString::fromUtf8("以单词为单位依次浮起 / 离开"))
-              .in().words().pos(0, 50).opacity(0).dur(1.2).soft(0.35).p);
-    addPreset(B("line-reveal", QString::fromUtf8("逐行展开"),
-                QString::fromUtf8("文字按行依次浮现 / 消失"))
-              .in().lines().pos(0, 36).opacity(0).dur(1.4).soft(0.4).p);
-    addPreset(B("rise-rtl", QString::fromUtf8("右起上浮"),
-                QString::fromUtf8("从右向左依次浮起 / 上飘离开"))
-              .in().letters().pos(0, 60).opacity(0).rtl().dur(1.2).soft(0.35).p);
-    addPreset(B("number-roll", QString::fromUtf8("数字滚动增长"),
-                QString::fromUtf8("数字从 0 滚动增长到当前数值（保留前后缀），仅入点"))
-              .in().letters().dur(1.6).p);
-    gPresets.last().supportsOut = false;
+    // =========================================================================
+    // 1. 锐利瞬态与冲击动力学（Kinetic Sharp - 25 项）
+    // =========================================================================
+    addPreset(B("sharp-snap-rise", QString::fromUtf8("迅猛上冲"),
+                QString::fromUtf8("从下方疾速上冲并带有硬朗刹车感"))
+              .in().letters().tag("sharp").pos(0, 90).opacity(0).dur(0.6).soft(0.12)
+              .easing(TextEasing::sharpSnap).stagger(0.35).p);
+    addPreset(B("sharp-snap-drop", QString::fromUtf8("急坠刹车"),
+                QString::fromUtf8("高空垂直极速俯冲并在着陆点骤停"))
+              .in().letters().tag("sharp").pos(0, -110).opacity(0).dur(0.6).soft(0.12)
+              .easing(TextEasing::sharpSnap).stagger(0.35).p);
+    addPreset(B("sharp-snap-left", QString::fromUtf8("左侧疾冲"),
+                QString::fromUtf8("自左侧高速瞬移滑入刹车"))
+              .in().letters().tag("sharp").pos(-130, 0).opacity(0).dur(0.6).soft(0.12)
+              .easing(TextEasing::sharpSnap).stagger(0.35).p);
+    addPreset(B("sharp-snap-right", QString::fromUtf8("右侧疾冲"),
+                QString::fromUtf8("自右侧高速瞬移滑入刹车"))
+              .in().letters().tag("sharp").pos(130, 0).opacity(0).dur(0.6).soft(0.12)
+              .easing(TextEasing::sharpSnap).stagger(0.35).p);
+    addPreset(B("sharp-overshoot-up", QString::fromUtf8("上冲回弹"),
+                QString::fromUtf8("大位移向上冲过头后轻微反弹就位"))
+              .in().letters().tag("sharp").pos(0, 100).scaleXY(0.9, 1.2).opacity(0).dur(0.7).soft(0.15)
+              .easing(TextEasing::overshoot).stagger(0.40).p);
+    addPreset(B("sharp-overshoot-down", QString::fromUtf8("重力回弹"),
+                QString::fromUtf8("向下重重砸落后反弹复位"))
+              .in().letters().tag("sharp").pos(0, -120).scaleXY(1.2, 0.8).opacity(0).dur(0.75).soft(0.15)
+              .easing(TextEasing::bounce).stagger(0.45).p);
+    addPreset(B("sharp-elastic-pop", QString::fromUtf8("高弹爆破"),
+                QString::fromUtf8("从零极速膨胀并伴随剧烈弹性振荡"))
+              .in().letters().tag("sharp").scale(0).opacity(0).center().dur(0.65).soft(0.12)
+              .easing(TextEasing::elastic).stagger(0.45).p);
+    addPreset(B("sharp-squash-h", QString::fromUtf8("横向挤压弹"),
+                QString::fromUtf8("横向拉伸3倍后像皮筋一样骤然收紧弹定"))
+              .in().letters().tag("sharp").scaleXY(3.2, 0.3).opacity(0).center().dur(0.7).soft(0.15)
+              .easing(TextEasing::elastic).stagger(0.40).p);
+    addPreset(B("sharp-squash-v", QString::fromUtf8("纵向重压弹"),
+                QString::fromUtf8("纵向极度压扁贴地后猛烈反弹站立"))
+              .in().letters().tag("sharp").scaleXY(0.3, 3.2).pos(0, -60).opacity(0).center().dur(0.75).soft(0.15)
+              .easing(TextEasing::bounce).stagger(0.45).p);
+    addPreset(B("sharp-whip-twist", QString::fromUtf8("鞭击抽打"),
+                QString::fromUtf8("快速大幅度旋转并伴随位移抽击落定"))
+              .in().letters().tag("sharp").rot(75).pos(-80, 40).opacity(0).center().dur(0.65).soft(0.12)
+              .easing(TextEasing::overshoot).stagger(0.35).p);
+    addPreset(B("sharp-whip-ccw", QString::fromUtf8("反向鞭甩"),
+                QString::fromUtf8("逆时针高速反抽甩入视界"))
+              .in().letters().tag("sharp").rot(-75).pos(80, 40).opacity(0).center().dur(0.65).soft(0.12)
+              .easing(TextEasing::overshoot).stagger(0.35).p);
+    addPreset(B("sharp-slam-front", QString::fromUtf8("正面撞击"),
+                QString::fromUtf8("从超大超近视距猛烈撞击砸入画面"))
+              .in().letters().tag("sharp").scale(4.0).opacity(0).center().dur(0.55).soft(0.1)
+              .easing(TextEasing::bounce).stagger(0.30).p);
+    addPreset(B("sharp-blade-cut", QString::fromUtf8("利刃切入"),
+                QString::fromUtf8("大角度斜切配合横向高速划割入场"))
+              .in().letters().tag("sharp").pos(-150, 0).shear(1.0, 0).opacity(0).dur(0.55).soft(0.1)
+              .easing(TextEasing::sharpSnap).stagger(0.30).p);
+    addPreset(B("sharp-blade-slash", QString::fromUtf8("纵向斜斩"),
+                QString::fromUtf8("垂直方向极速斜斩下切"))
+              .in().letters().tag("sharp").pos(0, -100).shear(0, 0.8).opacity(0).dur(0.6).soft(0.12)
+              .easing(TextEasing::sharpSnap).stagger(0.30).p);
+    addPreset(B("sharp-stagger-impact", QString::fromUtf8("顿挫重击"),
+                QString::fromUtf8("几乎无羽化的硬性顿挫逐字砸落"))
+              .in().letters().tag("sharp").pos(0, 70).opacity(0).dur(0.5).soft(0.04)
+              .easing(TextEasing::bounce).stagger(0.55).p);
+    addPreset(B("sharp-rebound-diag", QString::fromUtf8("对角弹射"),
+                QString::fromUtf8("沿45度对角线高速暴射进入反弹"))
+              .in().letters().tag("sharp").pos(-100, 100).rot(15).opacity(0).center().dur(0.65).soft(0.14)
+              .easing(TextEasing::overshoot).stagger(0.40).p);
+    addPreset(B("sharp-pop-jitter", QString::fromUtf8("硬脆爆字"),
+                QString::fromUtf8("零尺寸微小点瞬间炸裂绽放"))
+              .in().letters().tag("sharp").scale(0.05).rot(30).opacity(0).center().dur(0.5).soft(0.08)
+              .easing(TextEasing::elastic).stagger(0.40).p);
+    addPreset(B("sharp-punch-burst", QString::fromUtf8("重拳出击"),
+                QString::fromUtf8("极速前突放大并伴随缩放震荡"))
+              .in().letters().tag("sharp").scaleXY(0.4, 0.4).pos(0, 30).opacity(0).center().dur(0.6).soft(0.1)
+              .easing(TextEasing::overshoot).stagger(0.35).p);
+    addPreset(B("sharp-scissor-kick", QString::fromUtf8("剪刀错位"),
+                QString::fromUtf8("上下反向错位猛力咬合平正"))
+              .in().letters().tag("sharp").pos(0, -60).shear(-0.7, 0).opacity(0).dur(0.65).soft(0.12)
+              .easing(TextEasing::sharpSnap).stagger(0.35).p);
+    addPreset(B("sharp-spring-rise", QString::fromUtf8("弹簧跃起"),
+                QString::fromUtf8("自底部像紧压的弹簧猛然释放跳起"))
+              .in().letters().tag("sharp").pos(0, 120).scaleXY(0.7, 1.4).opacity(0).center().dur(0.7).soft(0.15)
+              .easing(TextEasing::elastic).stagger(0.45).p);
+    addPreset(B("sharp-snap-word-rise", QString::fromUtf8("逐词弹射"),
+                QString::fromUtf8("单词为单位的高速强力弹跃入场"))
+              .in().words().tag("sharp").pos(0, 80).opacity(0).dur(0.7).soft(0.15)
+              .easing(TextEasing::overshoot).stagger(0.45).p);
+    addPreset(B("sharp-snap-word-drop", QString::fromUtf8("逐词重砸"),
+                QString::fromUtf8("单词自上方高空高速俯冲砸落"))
+              .in().words().tag("sharp").pos(0, -100).scaleXY(1.2, 0.8).opacity(0).center().dur(0.7).soft(0.15)
+              .easing(TextEasing::bounce).stagger(0.45).p);
+    addPreset(B("sharp-snap-word-slam", QString::fromUtf8("逐词撞镜"),
+                QString::fromUtf8("单词近景超大比例极速拍打在屏幕上"))
+              .in().words().tag("sharp").scale(3.5).opacity(0).center().dur(0.6).soft(0.12)
+              .easing(TextEasing::bounce).stagger(0.40).p);
+    addPreset(B("sharp-snap-line-whip", QString::fromUtf8("逐行鞭扫"),
+                QString::fromUtf8("整行文本高速斜切鞭甩就位"))
+              .in().lines().tag("sharp").pos(-180, 0).shear(0.6, 0).opacity(0).dur(0.8).soft(0.15)
+              .easing(TextEasing::overshoot).stagger(0.40).p);
+    addPreset(B("sharp-snap-line-slam", QString::fromUtf8("逐行重扣"),
+                QString::fromUtf8("多行文本依次垂直暴扣砸定"))
+              .in().lines().tag("sharp").pos(0, -110).opacity(0).dur(0.75).soft(0.12)
+              .easing(TextEasing::bounce).stagger(0.45).p);
 
-    // ---- loops ----
-    addPreset(B("wave", QString::fromUtf8("波浪"),
-                QString::fromUtf8("波浪从文字上流过"))
-              .loop().letters().pos(0, 14).wave(2, 1.1).p);
-    addPreset(B("wave-sway", QString::fromUtf8("风吹摇摆"),
-                QString::fromUtf8("文字像被风吹动般摇摆"))
-              .loop().letters().rot(8).wave(3, 1.4).p);
-    addPreset(B("wave-fade", QString::fromUtf8("波浪闪烁"),
-                QString::fromUtf8("明暗呈波浪状流过文字"))
-              .loop().letters().opacity(40).wave(3, 0.9).p);
-    addPreset(B("breathe", QString::fromUtf8("呼吸"),
-                QString::fromUtf8("文字整体轻轻缩放呼吸"))
-              .loop().letters().scale(1.08).opacity(80).center().dur(1.6).pulse().p);
-    addPreset(B("jitter", QString::fromUtf8("抖动"),
-                QString::fromUtf8("文字高频轻微抖动"))
-              .loop().letters().pos(3, 2).dur(0.14).pulse().p);
-    addPreset(B("pulse-strong", QString::fromUtf8("强调脉冲"),
-                QString::fromUtf8("文字快速放大再收回，用于强调"))
-              .loop().letters().scale(1.25).opacity(70).center().dur(0.5).pulse().p);
+    // =========================================================================
+    // 2. 丝滑流体与影视长尾（Kinetic Smooth - 20 项）
+    // =========================================================================
+    addPreset(B("smooth-float-rise", QString::fromUtf8("云雾升腾"),
+                QString::fromUtf8("如云烟般超柔和长距离平滑袅袅升起"))
+              .in().letters().tag("smooth").pos(0, 80).opacity(0).dur(1.8).soft(0.65)
+              .easing(TextEasing::smooth).stagger(0.60).p);
+    addPreset(B("smooth-float-sink", QString::fromUtf8("落羽沉降"),
+                QString::fromUtf8("宛如轻羽在微风中慢速摇曳下落"))
+              .in().letters().tag("smooth").pos(0, -80).opacity(0).dur(1.8).soft(0.65)
+              .easing(TextEasing::smooth).stagger(0.60).p);
+    addPreset(B("smooth-glide-left", QString::fromUtf8("丝绸左滑"),
+                QString::fromUtf8("超大羽化丝滑自左向右长距蔓延"))
+              .in().letters().tag("smooth").pos(-120, 0).opacity(0).dur(1.6).soft(0.55)
+              .easing(TextEasing::smooth).stagger(0.55).p);
+    addPreset(B("smooth-glide-right", QString::fromUtf8("丝绸右滑"),
+                QString::fromUtf8("超大羽化丝滑自右向左长距蔓延"))
+              .in().letters().tag("smooth").pos(120, 0).opacity(0).dur(1.6).soft(0.55)
+              .easing(TextEasing::smooth).stagger(0.55).p);
+    addPreset(B("smooth-cinematic-fade", QString::fromUtf8("胶片渐显"),
+                QString::fromUtf8("电影级超平滑长曝光逐渐显现"))
+              .in().letters().tag("smooth").opacity(0).dur(2.2).soft(0.7)
+              .easing(TextEasing::smooth).stagger(0.65).p);
+    addPreset(B("smooth-focus-zoom", QString::fromUtf8("景深推镜"),
+                QString::fromUtf8("轻柔镜头微推，伴随渐变显露"))
+              .in().letters().tag("smooth").scale(0.6).opacity(0).center().dur(1.6).soft(0.5)
+              .easing(TextEasing::smooth).stagger(0.50).p);
+    addPreset(B("smooth-drift-diag-tl", QString::fromUtf8("左上幽浮"),
+                QString::fromUtf8("自左上方深邃空间斜向平缓飘浮而来"))
+              .in().letters().tag("smooth").pos(-70, -70).opacity(0).dur(1.7).soft(0.5)
+              .easing(TextEasing::smooth).stagger(0.50).p);
+    addPreset(B("smooth-drift-diag-tr", QString::fromUtf8("右上幽浮"),
+                QString::fromUtf8("自右上方深邃空间斜向平缓飘浮而来"))
+              .in().letters().tag("smooth").pos(70, -70).opacity(0).dur(1.7).soft(0.5)
+              .easing(TextEasing::smooth).stagger(0.50).p);
+    addPreset(B("smooth-drift-diag-bl", QString::fromUtf8("左下漫步"),
+                QString::fromUtf8("自左下方悠缓漫步升上地平线"))
+              .in().letters().tag("smooth").pos(-70, 70).opacity(0).dur(1.7).soft(0.5)
+              .easing(TextEasing::smooth).stagger(0.50).p);
+    addPreset(B("smooth-drift-diag-br", QString::fromUtf8("右下漫步"),
+                QString::fromUtf8("自右下方悠缓漫步升上地平线"))
+              .in().letters().tag("smooth").pos(70, 70).opacity(0).dur(1.7).soft(0.5)
+              .easing(TextEasing::smooth).stagger(0.50).p);
+    addPreset(B("smooth-gentle-tilt", QString::fromUtf8("微风轻抚"),
+                QString::fromUtf8("带有轻微倾角与微弱位移的优雅拂入"))
+              .in().letters().tag("smooth").pos(0, 30).shear(0.25, 0).opacity(0).dur(1.5).soft(0.45)
+              .easing(TextEasing::smooth).stagger(0.50).p);
+    addPreset(B("smooth-twirl-bloom", QString::fromUtf8("花瓣旋放"),
+                QString::fromUtf8("低转角慢速旋转绽放展开"))
+              .in().letters().tag("smooth").rot(30).scale(0.5).opacity(0).center().dur(1.6).soft(0.5)
+              .easing(TextEasing::smooth).stagger(0.50).p);
+    addPreset(B("smooth-waterfall", QString::fromUtf8("水幔倾泻"),
+                QString::fromUtf8("逐字如同瀑布水流柔美延绵垂挂"))
+              .in().letters().tag("smooth").pos(0, -60).scaleXY(0.9, 1.2).opacity(0).dur(1.7).soft(0.55)
+              .easing(TextEasing::smooth).stagger(0.55).p);
+    addPreset(B("smooth-aurora", QString::fromUtf8("极光漫卷"),
+                QString::fromUtf8("宽阔光带般在文本间轻柔流淌点亮"))
+              .in().letters().tag("smooth").pos(-40, 20).opacity(0).dur(2.0).soft(0.75)
+              .easing(TextEasing::smooth).stagger(0.65).p);
+    addPreset(B("smooth-word-float", QString::fromUtf8("逐词幽浮"),
+                QString::fromUtf8("单词单元的长尾优雅徐徐升起"))
+              .in().words().tag("smooth").pos(0, 60).opacity(0).dur(1.6).soft(0.5)
+              .easing(TextEasing::smooth).stagger(0.55).p);
+    addPreset(B("smooth-word-glide", QString::fromUtf8("逐词流光"),
+                QString::fromUtf8("单词单元依次自左侧滑出并展开"))
+              .in().words().tag("smooth").pos(-90, 0).opacity(0).dur(1.5).soft(0.45)
+              .easing(TextEasing::smooth).stagger(0.50).p);
+    addPreset(B("smooth-word-bloom", QString::fromUtf8("逐词绽放"),
+                QString::fromUtf8("单词居中舒缓放大显现"))
+              .in().words().tag("smooth").scale(0.4).opacity(0).center().dur(1.5).soft(0.45)
+              .easing(TextEasing::smooth).stagger(0.50).p);
+    addPreset(B("smooth-line-rise", QString::fromUtf8("逐行升腾"),
+                QString::fromUtf8("多行段落依次优雅上浮展开"))
+              .in().lines().tag("smooth").pos(0, 60).opacity(0).dur(1.8).soft(0.55)
+              .easing(TextEasing::smooth).stagger(0.55).p);
+    addPreset(B("smooth-line-fade", QString::fromUtf8("逐行漫溢"),
+                QString::fromUtf8("多行文字层层递进如墨色漫溢"))
+              .in().lines().tag("smooth").opacity(0).dur(1.8).soft(0.6)
+              .easing(TextEasing::smooth).stagger(0.60).p);
+    addPreset(B("smooth-line-slide", QString::fromUtf8("逐行徐进"),
+                QString::fromUtf8("多行排版依次优雅横向推入"))
+              .in().lines().tag("smooth").pos(-120, 0).opacity(0).dur(1.7).soft(0.5)
+              .easing(TextEasing::smooth).stagger(0.55).p);
+
+    // =========================================================================
+    // 3. 通道属性分离几何（Channel Properties - 25 项）
+    // =========================================================================
+    addPreset(B("prop-pos-x-left", QString::fromUtf8("纯X轴-左向进入"),
+                QString::fromUtf8("严格锁定水平X轴，纯位移无缩放旋转"))
+              .in().letters().tag("prop").pos(-140, 0).dur(1.0).soft(0.3)
+              .easing(TextEasing::sharpSnap).stagger(0.35).p);
+    addPreset(B("prop-pos-x-right", QString::fromUtf8("纯X轴-右向进入"),
+                QString::fromUtf8("严格锁定水平X轴，自右侧纯平移进入"))
+              .in().letters().tag("prop").pos(140, 0).dur(1.0).soft(0.3)
+              .easing(TextEasing::sharpSnap).stagger(0.35).p);
+    addPreset(B("prop-pos-y-up", QString::fromUtf8("纯Y轴-底部上升"),
+                QString::fromUtf8("严格锁定垂直Y轴，纯高度抬升就位"))
+              .in().letters().tag("prop").pos(0, 90).dur(1.0).soft(0.3)
+              .easing(TextEasing::overshoot).stagger(0.35).p);
+    addPreset(B("prop-pos-y-down", QString::fromUtf8("纯Y轴-顶部降落"),
+                QString::fromUtf8("严格锁定垂直Y轴，纯高度下降就位"))
+              .in().letters().tag("prop").pos(0, -90).dur(1.0).soft(0.3)
+              .easing(TextEasing::bounce).stagger(0.40).p);
+    addPreset(B("prop-scale-uniform", QString::fromUtf8("纯缩放-全尺寸扩张"),
+                QString::fromUtf8("居中纯等比缩放从0放大至100%"))
+              .in().letters().tag("prop").scale(0).center().dur(1.0).soft(0.3)
+              .easing(TextEasing::overshoot).stagger(0.35).p);
+    addPreset(B("prop-scale-shrink", QString::fromUtf8("纯缩放-远景缩小"),
+                QString::fromUtf8("居中纯等比缩放从2.5倍收缩至标准"))
+              .in().letters().tag("prop").scale(2.5).center().dur(1.1).soft(0.3)
+              .easing(TextEasing::overshoot).stagger(0.35).p);
+    addPreset(B("prop-scale-stretch-x", QString::fromUtf8("纯比例-横向拉宽"),
+                QString::fromUtf8("垂直高度不变，水平拉宽4倍聚拢"))
+              .in().letters().tag("prop").scaleXY(4.0, 1.0).center().dur(1.1).soft(0.35)
+              .easing(TextEasing::elastic).stagger(0.40).p);
+    addPreset(B("prop-scale-squeeze-y", QString::fromUtf8("纯比例-纵向拉长"),
+                QString::fromUtf8("水平宽度不变，垂直拉长4倍收缩"))
+              .in().letters().tag("prop").scaleXY(1.0, 4.0).center().dur(1.1).soft(0.35)
+              .easing(TextEasing::elastic).stagger(0.40).p);
+    addPreset(B("prop-scale-line-x", QString::fromUtf8("纯比例-横线延展"),
+                QString::fromUtf8("文字高度压缩为0呈细线横向展开"))
+              .in().letters().tag("prop").scaleXY(0, 1).center().dur(1.0).soft(0.25)
+              .easing(TextEasing::sharpSnap).stagger(0.30).p);
+    addPreset(B("prop-scale-bar-y", QString::fromUtf8("纯比例-坚柱立起"),
+                QString::fromUtf8("文字宽度压缩为0呈细柱纵向撑开"))
+              .in().letters().tag("prop").scaleXY(1, 0).center().dur(1.0).soft(0.25)
+              .easing(TextEasing::sharpSnap).stagger(0.30).p);
+    addPreset(B("prop-rot-cw-90", QString::fromUtf8("纯旋转-顺转90度"),
+                QString::fromUtf8("居中纯直角90度旋转摆正"))
+              .in().letters().tag("prop").rot(90).center().dur(1.1).soft(0.3)
+              .easing(TextEasing::overshoot).stagger(0.35).p);
+    addPreset(B("prop-rot-ccw-90", QString::fromUtf8("纯旋转-逆转90度"),
+                QString::fromUtf8("居中纯负90度逆向旋转摆正"))
+              .in().letters().tag("prop").rot(-90).center().dur(1.1).soft(0.3)
+              .easing(TextEasing::overshoot).stagger(0.35).p);
+    addPreset(B("prop-rot-cw-180", QString::fromUtf8("纯旋转-倒置翻转"),
+                QString::fromUtf8("纯180度半周回旋倒立翻转摆正"))
+              .in().letters().tag("prop").rot(180).center().dur(1.2).soft(0.35)
+              .easing(TextEasing::overshoot).stagger(0.40).p);
+    addPreset(B("prop-rot-full-360", QString::fromUtf8("纯旋转-整周回旋"),
+                QString::fromUtf8("纯360度整圈顺时针旋转进入"))
+              .in().letters().tag("prop").rot(360).center().dur(1.3).soft(0.35)
+              .easing(TextEasing::overshoot).stagger(0.40).p);
+    addPreset(B("prop-rot-sway-45", QString::fromUtf8("纯旋转-45度倾摆"),
+                QString::fromUtf8("45度对角倾摆复位"))
+              .in().letters().tag("prop").rot(45).center().dur(1.0).soft(0.25)
+              .easing(TextEasing::elastic).stagger(0.35).p);
+    addPreset(B("prop-shear-slash-x", QString::fromUtf8("纯斜切-水平倾斜"),
+                QString::fromUtf8("无旋转纯剪切力，倾角45度平移摆正"))
+              .in().letters().tag("prop").shear(0.8, 0).dur(1.0).soft(0.3)
+              .easing(TextEasing::sharpSnap).stagger(0.35).p);
+    addPreset(B("prop-shear-back-x", QString::fromUtf8("纯斜切-反向倾斜"),
+                QString::fromUtf8("反向水平剪切，倾角-45度摆正"))
+              .in().letters().tag("prop").shear(-0.8, 0).dur(1.0).soft(0.3)
+              .easing(TextEasing::sharpSnap).stagger(0.35).p);
+    addPreset(B("prop-shear-vertical", QString::fromUtf8("纯斜切-纵向切片"),
+                QString::fromUtf8("纵向剪切错位依次拉正"))
+              .in().letters().tag("prop").shear(0, 0.8).dur(1.0).soft(0.3)
+              .easing(TextEasing::sharpSnap).stagger(0.35).p);
+    addPreset(B("prop-shear-cross", QString::fromUtf8("纯斜切-十字交叉"),
+                QString::fromUtf8("双向同时剪切变形复原"))
+              .in().letters().tag("prop").shear(0.5, 0.5).dur(1.1).soft(0.35)
+              .easing(TextEasing::elastic).stagger(0.35).p);
+    addPreset(B("prop-opacity-stagger", QString::fromUtf8("纯透明度-阶梯淡入"),
+                QString::fromUtf8("位置比例完全静止，逐字阶梯渐显"))
+              .in().letters().tag("prop").opacity(0).dur(1.0).soft(0.1)
+              .easing(TextEasing::stepped).stagger(0.65).p);
+    addPreset(B("prop-opacity-steep", QString::fromUtf8("纯透明度-硬切显现"),
+                QString::fromUtf8("零过渡瞬间逐字亮起"))
+              .in().letters().tag("prop").opacity(0).dur(0.8).soft(0.02)
+              .easing(TextEasing::sharpSnap).stagger(0.50).p);
+    addPreset(B("prop-opacity-glow", QString::fromUtf8("纯透明度-呼吸渐显"),
+                QString::fromUtf8("超宽漫反射大羽化淡入"))
+              .in().letters().tag("prop").opacity(0).dur(1.6).soft(0.6)
+              .easing(TextEasing::smooth).stagger(0.65).p);
+    addPreset(B("prop-word-scale", QString::fromUtf8("逐词通道-等比放大"),
+                QString::fromUtf8("单词居中纯缩放显现"))
+              .in().words().tag("prop").scale(0).center().dur(1.0).soft(0.25)
+              .easing(TextEasing::overshoot).stagger(0.40).p);
+    addPreset(B("prop-word-rot", QString::fromUtf8("逐词通道-直角转入"),
+                QString::fromUtf8("单词顺时针90度转入"))
+              .in().words().tag("prop").rot(90).center().dur(1.1).soft(0.3)
+              .easing(TextEasing::overshoot).stagger(0.40).p);
+    addPreset(B("prop-line-shear", QString::fromUtf8("逐行通道-整体斜切"),
+                QString::fromUtf8("整行文本高速斜切拉直"))
+              .in().lines().tag("prop").shear(0.6, 0).dur(1.2).soft(0.3)
+              .easing(TextEasing::sharpSnap).stagger(0.45).p);
+
+    // =========================================================================
+    // 4. 空间与透视维度（3D Perspective - 12 项）
+    // =========================================================================
+    addPreset(B("3d-flip-y-cw", QString::fromUtf8("3D翻转-横向顺转"),
+                QString::fromUtf8("模拟绕Y轴3D立体卡片翻转入场"))
+              .in().letters().tag("3d").scaleXY(-0.1, 1.0).center().dur(1.0).soft(0.25)
+              .easing(TextEasing::overshoot).stagger(0.35).p);
+    addPreset(B("3d-flip-y-ccw", QString::fromUtf8("3D翻转-横向逆转"),
+                QString::fromUtf8("模拟绕Y轴逆向3D翻出就位"))
+              .in().letters().tag("3d").scaleXY(0.01, 1.0).shear(-0.3, 0).center().dur(1.0).soft(0.25)
+              .easing(TextEasing::overshoot).stagger(0.35).p);
+    addPreset(B("3d-flip-x-down", QString::fromUtf8("3D翻折-百叶下翻"),
+                QString::fromUtf8("模拟绕X轴水平轴线向下翻折展开"))
+              .in().letters().tag("3d").scaleXY(1.0, -0.1).center().dur(1.0).soft(0.25)
+              .easing(TextEasing::bounce).stagger(0.40).p);
+    addPreset(B("3d-flip-x-up", QString::fromUtf8("3D翻折-百叶上翻"),
+                QString::fromUtf8("模拟绕X轴水平轴线自下向上翻折"))
+              .in().letters().tag("3d").scaleXY(1.0, 0.01).pos(0, 30).center().dur(1.0).soft(0.25)
+              .easing(TextEasing::overshoot).stagger(0.35).p);
+    addPreset(B("3d-perspective-drop", QString::fromUtf8("3D俯冲坠入"),
+                QString::fromUtf8("大景深纵深透视自镜头高远深处俯冲砸下"))
+              .in().letters().tag("3d").scale(3.2).pos(0, -90).opacity(0).center().dur(1.2).soft(0.3)
+              .easing(TextEasing::bounce).stagger(0.40).p);
+    addPreset(B("3d-perspective-rise", QString::fromUtf8("3D仰天飞出"),
+                QString::fromUtf8("自地平面以下纵深透视角度破土冲出"))
+              .in().letters().tag("3d").scale(0.15).pos(0, 100).opacity(0).center().dur(1.2).soft(0.3)
+              .easing(TextEasing::overshoot).stagger(0.40).p);
+    addPreset(B("3d-tumble-diag", QString::fromUtf8("3D对角翻滚"),
+                QString::fromUtf8("双轴混合立体翻滚入场"))
+              .in().letters().tag("3d").scaleXY(-0.2, 0.2).rot(45).opacity(0).center().dur(1.2).soft(0.3)
+              .easing(TextEasing::elastic).stagger(0.40).p);
+    addPreset(B("3d-corkscrew", QString::fromUtf8("3D螺旋穿刺"),
+                QString::fromUtf8("沿纵深轴旋转360度穿刺飞出"))
+              .in().letters().tag("3d").scale(0.1).rot(360).opacity(0).center().dur(1.4).soft(0.35)
+              .easing(TextEasing::anticipate).stagger(0.45).p);
+    addPreset(B("3d-depth-zoom", QString::fromUtf8("3D空间推远"),
+                QString::fromUtf8("自画面正前方极近处穿透后退至焦点"))
+              .in().letters().tag("3d").scale(4.5).opacity(0).center().dur(1.1).soft(0.3)
+              .easing(TextEasing::bounce).stagger(0.35).p);
+    addPreset(B("3d-yaw-swing", QString::fromUtf8("3D偏航悬摆"),
+                QString::fromUtf8("如挂在立轴上的广告牌3D悬摆定型"))
+              .in().letters().tag("3d").rot(40).scaleXY(0.4, 1.0).opacity(0).center().dur(1.1).soft(0.28)
+              .easing(TextEasing::elastic).stagger(0.40).p);
+    addPreset(B("3d-word-flip", QString::fromUtf8("逐词3D翻转"),
+                QString::fromUtf8("单词为单位绕纵轴依次3D翻面展现"))
+              .in().words().tag("3d").scaleXY(-0.1, 1.0).center().dur(1.1).soft(0.28)
+              .easing(TextEasing::overshoot).stagger(0.40).p);
+    addPreset(B("3d-line-fold", QString::fromUtf8("逐行3D折叠"),
+                QString::fromUtf8("多行文字如同三折页宣传册立体翻开"))
+              .in().lines().tag("3d").scaleXY(1.0, -0.1).center().dur(1.2).soft(0.3)
+              .easing(TextEasing::overshoot).stagger(0.45).p);
+
+    // =========================================================================
+    // 5. 极客终端与离散时序（Code & Terminal - 8 项）
+    // =========================================================================
+    addPreset(B("tech-typewriter-std", QString::fromUtf8("标准打字机"),
+                QString::fromUtf8("经典终端逐字敲入，硬性光标级顿挫"))
+              .in().letters().tag("tech").opacity(0).dur(1.5).soft(0.04)
+              .easing(TextEasing::stepped).stagger(0.85).p);
+    addPreset(B("tech-typewriter-fast", QString::fromUtf8("高速代码输入"),
+                QString::fromUtf8("极速计算机黑客命令行逐字灌入"))
+              .in().letters().tag("tech").opacity(0).dur(0.75).soft(0.02)
+              .easing(TextEasing::stepped).stagger(0.85).p);
+    addPreset(B("tech-typewriter-slow", QString::fromUtf8("机械击字机"),
+                QString::fromUtf8("沉重慢速机械铅字逐字敲击印上纸面"))
+              .in().letters().tag("tech").opacity(0).dur(2.5).soft(0.02)
+              .easing(TextEasing::stepped).stagger(0.85).p);
+    addPreset(B("tech-number-roll", QString::fromUtf8("数字滚动增长"),
+                QString::fromUtf8("数字从 0 滚动增长到当前数值（保留前后缀），仅入点"))
+              .in().letters().tag("tech").dur(1.6).p);
+    gPresets.last().supportsOut = false;
+    addPreset(B("tech-cursor-stream", QString::fromUtf8("光标流接入"),
+                QString::fromUtf8("带有垂直微位移的数据流跳动录入"))
+              .in().letters().tag("tech").pos(0, -18).opacity(0).dur(1.1).soft(0.06)
+              .easing(TextEasing::sharpSnap).stagger(0.65).p);
+    addPreset(B("tech-glitch-burst", QString::fromUtf8("故障瞬切"),
+                QString::fromUtf8("数字故障偏折错位瞬间复原显现"))
+              .in().letters().tag("tech").pos(12, -6).rot(5).opacity(0).dur(0.9).soft(0.06)
+              .easing(TextEasing::stepped).stagger(0.70).p);
+    addPreset(B("tech-matrix-rain", QString::fromUtf8("矩阵代码雨"),
+                QString::fromUtf8("代码从天顶逐列疾速降落接入系统"))
+              .in().letters().tag("tech").pos(0, -45).opacity(0).dur(1.2).soft(0.07)
+              .easing(TextEasing::sharpSnap).stagger(0.75).p);
+    addPreset(B("tech-cyber-step", QString::fromUtf8("阶梯二进制"),
+                QString::fromUtf8("段落感分明的离散二进制电平跳跃跳入"))
+              .in().letters().tag("tech").pos(0, 30).opacity(0).dur(1.0).soft(0.05)
+              .easing(TextEasing::stepped).stagger(0.80).p);
+
+    // =========================================================================
+    // 6. 持续波动与周期循环（Continuous Loops - 15 项）
+    // =========================================================================
+    addPreset(B("loop-sine-wave", QString::fromUtf8("标准正弦波"),
+                QString::fromUtf8("柔美正弦水波在文字间连绵传递流淌"))
+              .loop().letters().tag("loop").pos(0, 14).wave(2, 1.1).p);
+    addPreset(B("loop-fast-ripple", QString::fromUtf8("急促涟漪"),
+                QString::fromUtf8("高频率小振幅水纹疾速拂过"))
+              .loop().letters().tag("loop").pos(0, 12).wave(4, 0.6).p);
+    addPreset(B("loop-bouncy-hop", QString::fromUtf8("波浪跳跃"),
+                QString::fromUtf8("文字按波形依次原地欢快跳跃"))
+              .loop().letters().tag("loop").pos(0, 24).wave(2, 0.8).p);
+    addPreset(B("loop-wind-sway", QString::fromUtf8("风吹麦浪"),
+                QString::fromUtf8("左右角度周期性倾斜摇曳"))
+              .loop().letters().tag("loop").rot(9).wave(3, 1.4).p);
+    addPreset(B("loop-flow-light", QString::fromUtf8("流光溢彩"),
+                QString::fromUtf8("光斑与透明度呈波浪状在文字间流转"))
+              .loop().letters().tag("loop").opacity(35).wave(3, 1.0).p);
+    addPreset(B("loop-skew-groove", QString::fromUtf8("倾斜律动"),
+                QString::fromUtf8("动感斜切剪切角周期性波形传导"))
+              .loop().letters().tag("loop").shear(0.3, 0).wave(2, 1.2).p);
+    addPreset(B("loop-stretch-pulse", QString::fromUtf8("压扁拉伸波"),
+                QString::fromUtf8("交替压扁与拉长的弹性形变波浪"))
+              .loop().letters().tag("loop").scaleXY(1.18, 0.82).wave(2, 1.1).p);
+    addPreset(B("loop-breathe-soft", QString::fromUtf8("轻柔呼吸"),
+                QString::fromUtf8("全体文字柔和均匀微弱缩放呼吸"))
+              .loop().letters().tag("loop").scale(1.08).opacity(80).center().dur(1.6).pulse().p);
+    addPreset(B("loop-breathe-deep", QString::fromUtf8("深沉呼吸"),
+                QString::fromUtf8("大幅度舒展的慢速深呼吸"))
+              .loop().letters().tag("loop").scale(1.2).opacity(60).center().dur(2.4).pulse().p);
+    addPreset(B("loop-heartbeat", QString::fromUtf8("心跳脉动"),
+                QString::fromUtf8("双重强弱律动的紧凑心跳节奏"))
+              .loop().letters().tag("loop").scale(1.2).center().dur(0.75).pulse().p);
+    addPreset(B("loop-gentle-float", QString::fromUtf8("气泡悬浮"),
+                QString::fromUtf8("仿佛失重空间中低频起伏悬停"))
+              .loop().letters().tag("loop").pos(0, 10).wave(1, 2.5).p);
+    addPreset(B("loop-micro-jitter", QString::fromUtf8("高频抖颤"),
+                QString::fromUtf8("文字高频微弱颤抖表现紧张或不稳定"))
+              .loop().letters().tag("loop").pos(3, 2).dur(0.12).pulse().p);
+    addPreset(B("loop-glitch-twitch", QString::fromUtf8("故障抽搐"),
+                QString::fromUtf8("突发性错位与偏折的电磁干扰抖动"))
+              .loop().letters().tag("loop").pos(8, 5).rot(3).dur(0.1).pulse().p);
+    addPreset(B("loop-neon-flicker", QString::fromUtf8("霓虹灯闪烁"),
+                QString::fromUtf8("老旧霓虹灯管般的剧烈明暗频闪"))
+              .loop().letters().tag("loop").opacity(15).dur(0.2).pulse().p);
+    addPreset(B("loop-orbit-dance", QString::fromUtf8("轨道巡游"),
+                QString::fromUtf8("微幅旋转结合位移的立体椭圆漫游"))
+              .loop().letters().tag("loop").pos(5, 7).rot(5).wave(2, 1.5).p);
+
+    // =========================================================================
+    // 6. 新增动力学拓展：弹性与物理重击（Elastic & Physics Bounce Expanded）
+    // =========================================================================
+    addPreset(B("sharp-double-bounce", QString::fromUtf8("双重回弹"),
+                QString::fromUtf8("重力砸地后产生两次清脆的回弹落定"))
+              .in().letters().tag("sharp").pos(0, -180).easing(TextEasing::bounce).stagger(0.35).dur(0.9).p);
+    addPreset(B("sharp-jelly-squash", QString::fromUtf8("果冻挤压"),
+                QString::fromUtf8("如弹性果冻般受力压缩后弹回原状"))
+              .in().letters().tag("sharp").scaleXY(1.6, 0.4).easing(TextEasing::elastic).stagger(0.40).dur(0.85).p);
+    addPreset(B("sharp-trampoline", QString::fromUtf8("蹦床弹跃"),
+                QString::fromUtf8("文字如蹦床般自底部高速弹入并小幅减速落定"))
+              .in().letters().tag("sharp").pos(0, 160).scaleY(1.35).easing(TextEasing::bounce).stagger(0.45).dur(0.8).p);
+    addPreset(B("sharp-rubber-whip", QString::fromUtf8("胶带抽拉"),
+                QString::fromUtf8("受橡皮筋拉伸般伴随大剪切角瞬时回弹抽正"))
+              .in().letters().tag("sharp").shear(0.65, 0).scaleX(1.4).easing(TextEasing::elastic).stagger(0.30).dur(0.75).p);
+    addPreset(B("sharp-anvil-slam", QString::fromUtf8("铁砧重砸"),
+                QString::fromUtf8("超重力高空坠地砸落，伴随垂直形变与地面震感"))
+              .in().letters().tag("sharp").pos(0, -260).scaleY(0.65).easing(TextEasing::bounce).stagger(0.25).dur(0.7).p);
+    addPreset(B("sharp-domino-fall", QString::fromUtf8("多米诺骨牌"),
+                QString::fromUtf8("如骨牌依次向后蓄力后翻转立起"))
+              .in().letters().tag("sharp").rot(-85).pos(0, 40).easing(TextEasing::anticipate).stagger(0.60).dur(0.85).p);
+    addPreset(B("sharp-gelatin-settle", QString::fromUtf8("微震软胶"),
+                QString::fromUtf8("软胶质感微幅谐振衰减落定"))
+              .in().letters().tag("sharp").scale(1.35).easing(TextEasing::elastic).stagger(0.35).dur(0.7).p);
+    addPreset(B("sharp-horizontal-whip", QString::fromUtf8("横向鞭响"),
+                QString::fromUtf8("水平超高速疾速斩出并在末端急停抽击"))
+              .in().letters().tag("sharp").pos(320, 0).shear(0.45, 0).easing(TextEasing::sharpSnap).stagger(0.20).dur(0.6).p);
+    addPreset(B("sharp-vertical-rebound", QString::fromUtf8("纵向回冲"),
+                QString::fromUtf8("从下方超速上冲冲过头后反拉到位"))
+              .in().letters().tag("sharp").pos(0, 180).easing(TextEasing::overshoot).stagger(0.35).dur(0.7).p);
+    addPreset(B("sharp-jack-in-box", QString::fromUtf8("惊奇弹簧盒"),
+                QString::fromUtf8("自缩微极小点破壳弹出伴随强劲多重阻尼回弹"))
+              .in().letters().tag("sharp").scale(0.05).pos(0, 80).easing(TextEasing::elastic).stagger(0.40).dur(0.9).p);
+    addPreset(B("sharp-recoil-blast", QString::fromUtf8("后坐力喷射"),
+                QString::fromUtf8("火炮后坐力般先剧烈后撤蓄势再高爆发喷射到位"))
+              .in().letters().tag("sharp").pos(-90, 0).scale(1.25).easing(TextEasing::anticipate).stagger(0.30).dur(0.65).p);
+    addPreset(B("sharp-slap-down", QString::fromUtf8("重掌拍击"),
+                QString::fromUtf8("由上向下如重掌拍在台面上般扁平触地"))
+              .in().letters().tag("sharp").pos(0, -130).scaleXY(1.45, 0.55).easing(TextEasing::bounce).stagger(0.35).dur(0.75).p);
+    addPreset(B("sharp-scissor-cut-v", QString::fromUtf8("垂直纵切"),
+                QString::fromUtf8("垂直刀刃高速纵向切削进入"))
+              .in().letters().tag("sharp").pos(0, 150).shear(0, 0.4).easing(TextEasing::sharpSnap).stagger(0.25).dur(0.6).p);
+    addPreset(B("sharp-cascade-word-pop", QString::fromUtf8("逐词阶梯跃"),
+                QString::fromUtf8("单词按阶梯节拍依次如弹簧般跃起"))
+              .in().words().tag("sharp").pos(0, 90).easing(TextEasing::elastic).stagger(0.60).dur(0.9).p);
+    addPreset(B("sharp-line-rebound-drop", QString::fromUtf8("逐行弹跳落"),
+                QString::fromUtf8("整行文字以重力加速度逐行砸落弹跳"))
+              .in().lines().tag("sharp").pos(0, -110).easing(TextEasing::bounce).stagger(0.50).dur(0.85).p);
+
+    // =========================================================================
+    // 7. 新增丝滑流体与影视字幕（Kinetic Smooth & Fluid Expanded）
+    // =========================================================================
+    addPreset(B("smooth-par-float", QString::fromUtf8("视差浮出"),
+                QString::fromUtf8("多维坐标微位移与透明度优雅漫步显形"))
+              .in().letters().tag("smooth").pos(30, 60).opacity(0).easing(TextEasing::smooth).stagger(0.50).dur(1.2).soft(0.35).p);
+    addPreset(B("smooth-velvet-slide", QString::fromUtf8("天鹅绒轻推"),
+                QString::fromUtf8("丝绒质感水平低速滑入，边缘柔焦漫化"))
+              .in().letters().tag("smooth").pos(-120, 0).opacity(0).easing(TextEasing::smooth).stagger(0.40).dur(1.1).soft(0.45).p);
+    addPreset(B("smooth-bloom-slow", QString::fromUtf8("空灵微绽"),
+                QString::fromUtf8("宛如花朵在静谧晨光中缓慢绽开"))
+              .in().letters().tag("smooth").scale(0.7).opacity(0).easing(TextEasing::smooth).stagger(0.45).dur(1.4).soft(0.3).p);
+    addPreset(B("smooth-mist-spread", QString::fromUtf8("晨雾弥漫"),
+                QString::fromUtf8("大范围柔和渐变与微缩放交织如晨雾扩散"))
+              .in().letters().tag("smooth").scale(1.15).opacity(0).easing(TextEasing::smooth).stagger(0.55).dur(1.3).soft(0.5).p);
+    addPreset(B("smooth-drift-ne", QString::fromUtf8("东北幽浮"),
+                QString::fromUtf8("向东北对角线优雅轻柔飘移进入"))
+              .in().letters().tag("smooth").pos(-80, 80).opacity(0).easing(TextEasing::smooth).stagger(0.45).dur(1.15).soft(0.3).p);
+    addPreset(B("smooth-drift-sw", QString::fromUtf8("西南游弋"),
+                QString::fromUtf8("向西南对角线静谧游弋入画"))
+              .in().letters().tag("smooth").pos(80, -80).opacity(0).easing(TextEasing::smooth).stagger(0.45).dur(1.15).soft(0.3).p);
+    addPreset(B("smooth-waterfall-drop", QString::fromUtf8("水瀑垂落"),
+                QString::fromUtf8("如瀑布水帘垂落，透明度随行间渐次倾泻"))
+              .in().letters().tag("smooth").pos(0, -140).opacity(0).easing(TextEasing::smooth).stagger(0.40).dur(1.2).soft(0.35).p);
+    addPreset(B("smooth-dawn-rise", QString::fromUtf8("破晓初升"),
+                QString::fromUtf8("自下方轻盈抬升并伴随微小尺寸舒展"))
+              .in().letters().tag("smooth").pos(0, 90).scale(0.9).opacity(0).easing(TextEasing::smooth).stagger(0.45).dur(1.2).p);
+    addPreset(B("smooth-word-mist", QString::fromUtf8("逐词迷雾"),
+                QString::fromUtf8("每个词语如同自薄雾深处逐一浮现显影"))
+              .in().words().tag("smooth").scale(1.1).opacity(0).easing(TextEasing::smooth).stagger(0.50).dur(1.3).soft(0.4).p);
+    addPreset(B("smooth-word-glimmer", QString::fromUtf8("逐词微光"),
+                QString::fromUtf8("逐词以微小位移和柔和亮度渐次点亮"))
+              .in().words().tag("smooth").pos(0, 30).opacity(20).easing(TextEasing::smooth).stagger(0.50).dur(1.1).p);
+    addPreset(B("smooth-line-cascade-up", QString::fromUtf8("逐行梯次升"),
+                QString::fromUtf8("排版文本逐行优雅梯次抬升就位"))
+              .in().lines().tag("smooth").pos(0, 60).opacity(0).easing(TextEasing::smooth).stagger(0.55).dur(1.2).p);
+    addPreset(B("smooth-line-curtain", QString::fromUtf8("逐行帘幕拉"),
+                QString::fromUtf8("宛如幕布横向轻柔拉开显露整行文本"))
+              .in().lines().tag("smooth").pos(-150, 0).opacity(0).easing(TextEasing::smooth).stagger(0.50).dur(1.1).soft(0.4).p);
+
+    // =========================================================================
+    // 8. 新增通道属性与形变（Channel Properties Expanded）
+    // =========================================================================
+    addPreset(B("prop-scale-wide-8x", QString::fromUtf8("极致横向拉伸"),
+                QString::fromUtf8("横向压缩 8 倍后以超强爆发力弹开铺平"))
+              .in().letters().tag("prop").scaleXY(8.0, 1.0).opacity(0).easing(TextEasing::sharpSnap).stagger(0.30).dur(0.7).p);
+    addPreset(B("prop-scale-tall-8x", QString::fromUtf8("极致天顶拔起"),
+                QString::fromUtf8("纵向拉伸 8 倍从天顶如擎天柱般拔地而起"))
+              .in().letters().tag("prop").scaleXY(1.0, 8.0).opacity(0).easing(TextEasing::sharpSnap).stagger(0.30).dur(0.7).p);
+    addPreset(B("prop-shear-lean-left", QString::fromUtf8("向左倾角切"),
+                QString::fromUtf8("左侧动感大倾角剪切并高速摆正"))
+              .in().letters().tag("prop").shear(-0.8, 0).easing(TextEasing::sharpSnap).stagger(0.35).dur(0.65).p);
+    addPreset(B("prop-shear-lean-right", QString::fromUtf8("向右倾角切"),
+                QString::fromUtf8("右侧动感大倾角剪切并高速摆正"))
+              .in().letters().tag("prop").shear(0.8, 0).easing(TextEasing::sharpSnap).stagger(0.35).dur(0.65).p);
+    addPreset(B("prop-rot-ccw-360", QString::fromUtf8("逆时针全回转"),
+                QString::fromUtf8("逆时针 360 度自转并伴随轻微过冲回摆"))
+              .in().letters().tag("prop").rot(-360).easing(TextEasing::overshoot).stagger(0.45).dur(0.9).p);
+    addPreset(B("prop-rot-pendulum", QString::fromUtf8("钟摆起摇"),
+                QString::fromUtf8("自 75 度大倾角如钟摆放手般弹性衰减摇正"))
+              .in().letters().tag("prop").rot(75).easing(TextEasing::elastic).stagger(0.40).dur(1.1).p);
+    addPreset(B("prop-pos-diagonal-down", QString::fromUtf8("对角急冲入"),
+                QString::fromUtf8("自左上方 45 度角高速俯冲归位"))
+              .in().letters().tag("prop").pos(-150, -150).easing(TextEasing::sharpSnap).stagger(0.30).dur(0.65).p);
+    addPreset(B("prop-pos-diagonal-up", QString::fromUtf8("仰冲对角"),
+                QString::fromUtf8("自右下方 45 度角高速仰冲归位"))
+              .in().letters().tag("prop").pos(150, 150).easing(TextEasing::sharpSnap).stagger(0.30).dur(0.65).p);
+    addPreset(B("prop-word-scale-explode", QString::fromUtf8("逐词膨胀炸裂"),
+                QString::fromUtf8("词语从 2.5 倍超大尺寸剧烈收缩炸落"))
+              .in().words().tag("prop").scale(2.5).opacity(0).easing(TextEasing::overshoot).stagger(0.55).dur(0.85).p);
+    addPreset(B("prop-line-shear-wave", QString::fromUtf8("逐行错位剪切"),
+                QString::fromUtf8("行间剪切角波浪式错开归位"))
+              .in().lines().tag("prop").shear(0.5, 0).easing(TextEasing::overshoot).stagger(0.50).dur(0.8).p);
+
+    // =========================================================================
+    // 9. 新增 3D 空间立体构造（3D Spatial Kinetics Expanded）
+    // =========================================================================
+    addPreset(B("3d-barrel-roll", QString::fromUtf8("3D滚筒翻滚"),
+                QString::fromUtf8("文字沿 X 轴翻滚并伴随蓄力后撤"))
+              .in().letters().tag("3d").rot(180).scale(0.5).easing(TextEasing::anticipate).stagger(0.40).dur(0.9).p);
+    addPreset(B("3d-vortex-in", QString::fromUtf8("3D旋涡漏斗"),
+                QString::fromUtf8("从微型漏斗中心高速螺旋放大飞出"))
+              .in().letters().tag("3d").rot(270).scale(0.15).opacity(0).easing(TextEasing::sharpSnap).stagger(0.45).dur(0.85).p);
+    addPreset(B("3d-cube-fold-top", QString::fromUtf8("3D顶折立方"),
+                QString::fromUtf8("立方体顶面般自上方 90 度折叠掀开入场"))
+              .in().letters().tag("3d").rot(90).pos(0, -60).easing(TextEasing::overshoot).stagger(0.40).dur(0.8).p);
+    addPreset(B("3d-cube-fold-bottom", QString::fromUtf8("3D底折掀开"),
+                QString::fromUtf8("立方体底面般自下方 90 度翻起就位"))
+              .in().letters().tag("3d").rot(-90).pos(0, 60).easing(TextEasing::overshoot).stagger(0.40).dur(0.8).p);
+    addPreset(B("3d-door-swing-left", QString::fromUtf8("3D门扉单开"),
+                QString::fromUtf8("以左侧边框为轴如开门般 90 度推开"))
+              .in().letters().tag("3d").rot(-90).pos(-80, 0).easing(TextEasing::anticipate).stagger(0.40).dur(0.85).p);
+    addPreset(B("3d-door-swing-right", QString::fromUtf8("3D门扉右开"),
+                QString::fromUtf8("以右侧边框为轴如开门般 90 度拉开"))
+              .in().letters().tag("3d").rot(90).pos(80, 0).easing(TextEasing::anticipate).stagger(0.40).dur(0.85).p);
+    addPreset(B("3d-spatial-fan", QString::fromUtf8("3D空间扇形展开"),
+                QString::fromUtf8("文字沿空间圆弧扇面逐字展开摆正"))
+              .in().letters().tag("3d").rot(60).scale(0.6).easing(TextEasing::elastic).stagger(0.50).dur(1.0).p);
+    addPreset(B("3d-depth-push", QString::fromUtf8("3D景深前推"),
+                QString::fromUtf8("自深度景深原点瞬间放大冲到镜头前"))
+              .in().letters().tag("3d").scale(0.05).opacity(0).easing(TextEasing::overshoot).stagger(0.35).dur(0.75).p);
+    addPreset(B("3d-word-flip-cascade", QString::fromUtf8("逐词3D阶梯翻转"),
+                QString::fromUtf8("词语沿空间轴依次翻折 90 度落定"))
+              .in().words().tag("3d").rot(90).easing(TextEasing::overshoot).stagger(0.55).dur(0.9).p);
+    addPreset(B("3d-line-fold-cascade", QString::fromUtf8("逐行3D折叠推落"),
+                QString::fromUtf8("整行文字沿水平轴如百叶窗翻折就位"))
+              .in().lines().tag("3d").rot(-90).easing(TextEasing::overshoot).stagger(0.50).dur(0.85).p);
+
+    // =========================================================================
+    // 10. 新增赛博极客与故障解码（Cyber Glitch & Tech Expanded）
+    // =========================================================================
+    addPreset(B("tech-binary-matrix", QString::fromUtf8("二进制阵列解算"),
+                QString::fromUtf8("数字矩阵运算般离散 5 阶量子跳变入场"))
+              .in().letters().tag("tech").pos(0, 20).opacity(0).easing(TextEasing::stepped).stagger(0.65).dur(0.75).p);
+    addPreset(B("tech-hex-decode", QString::fromUtf8("十六进制跳变解码"),
+                QString::fromUtf8("十六进制跳变阶跃显示"))
+              .in().letters().tag("tech").scale(0.8).opacity(0).easing(TextEasing::stepped).stagger(0.60).dur(0.8).p);
+    addPreset(B("tech-crt-scan", QString::fromUtf8("CRT显像管横扫"),
+                QString::fromUtf8("老式显像管电子枪横扫点亮，先扁后正"))
+              .in().letters().tag("tech").scaleXY(2.0, 0.1).opacity(0).easing(TextEasing::sharpSnap).stagger(0.30).dur(0.6).p);
+    addPreset(B("tech-radar-sweep", QString::fromUtf8("雷达波速扫"),
+                QString::fromUtf8("雷达波束圆周扫描后迅速点亮"))
+              .in().letters().tag("tech").rot(90).opacity(0).easing(TextEasing::smooth).stagger(0.40).dur(0.8).soft(0.3).p);
+    addPreset(B("tech-terminal-blink", QString::fromUtf8("终端命令闪进"),
+                QString::fromUtf8("光标停留后瞬间硬切显现的硬朗终端命令"))
+              .in().letters().tag("tech").opacity(0).easing(TextEasing::stepped).stagger(0.70).dur(0.65).p);
+    addPreset(B("tech-strobe-alert", QString::fromUtf8("频闪警报切入"),
+                QString::fromUtf8("警报频闪信号快速同步显影"))
+              .in().letters().tag("tech").opacity(10).easing(TextEasing::stepped).stagger(0.50).dur(0.5).p);
+    addPreset(B("tech-analog-noise", QString::fromUtf8("模拟噪波切片"),
+                QString::fromUtf8("伴随水平剪切与离散错位的模拟信号波"))
+              .in().letters().tag("tech").pos(25, 0).shear(0.3, 0).easing(TextEasing::stepped).stagger(0.55).dur(0.7).p);
+    addPreset(B("tech-digital-glitch-drop", QString::fromUtf8("数字故障跌落"),
+                QString::fromUtf8("离散步进下落带有角度偏转的故障风格"))
+              .in().letters().tag("tech").pos(0, -40).rot(10).easing(TextEasing::stepped).stagger(0.50).dur(0.6).p);
+    addPreset(B("tech-quantum-jump", QString::fromUtf8("量子跳跃显影"),
+                QString::fromUtf8("尺寸在离散步进间跳变放大最终定格"))
+              .in().letters().tag("tech").scale(1.5).opacity(0).easing(TextEasing::stepped).stagger(0.45).dur(0.65).p);
+    addPreset(B("tech-code-decrypt-word", QString::fromUtf8("逐词代码破译"),
+                QString::fromUtf8("词语级阶跃解密显现"))
+              .in().words().tag("tech").opacity(0).easing(TextEasing::stepped).stagger(0.60).dur(0.7).p);
+
+    // =========================================================================
+    // 11. 新增持续文字循环动效（Continuous Loops Expanded）
+    // =========================================================================
+    addPreset(B("loop-rainbow-wave", QString::fromUtf8("波形起伏浪"),
+                QString::fromUtf8("4 周期密集起伏水波"))
+              .loop().letters().tag("loop").pos(0, 15).wave(4, 1.0).p);
+    addPreset(B("loop-liquid-ripple", QString::fromUtf8("液体涟漪"),
+                QString::fromUtf8("微小形变膨胀拉伸的液体循环波"))
+              .loop().letters().tag("loop").scaleXY(1.1, 0.9).wave(3, 1.2).p);
+    addPreset(B("loop-pendulum-swing", QString::fromUtf8("单摆悬荡"),
+                QString::fromUtf8("单周期宽幅钟摆持续摇荡"))
+              .loop().letters().tag("loop").rot(12).wave(1, 1.6).p);
+    addPreset(B("loop-earthquake", QString::fromUtf8("震颤共振"),
+                QString::fromUtf8("超高频急促共振抖动"))
+              .loop().letters().tag("loop").pos(5, 4).dur(0.08).pulse().p);
+    addPreset(B("loop-zero-gravity", QString::fromUtf8("失重微沉浮"),
+                QString::fromUtf8("太空失重环境极慢起伏悬停"))
+              .loop().letters().tag("loop").pos(0, 8).dur(2.8).pulse().p);
+    addPreset(B("loop-neon-strobe", QString::fromUtf8("高频霓虹频闪"),
+                QString::fromUtf8("极低暗度的高速频闪电光循环"))
+              .loop().letters().tag("loop").opacity(5).dur(0.15).pulse().p);
 }
 }
 
@@ -187,7 +783,7 @@ bool apply(TextBox* const box,
            const bool out)
 {
     if (!box) { return false; }
-    if (preset.id == "number-roll") {
+    if (preset.id == "tech-number-roll" || preset.id == "number-roll") {
         // bake text keys counting 0 -> N, preserving any prefix and
         // suffix around the number (e.g. "progress: 42%")
         const QRegularExpression re(QStringLiteral("(\\D*)(-?\\d+)(\\D*)"));
@@ -363,8 +959,8 @@ bool textAnimDebugDumpFrames(const QString& outDir)
         Q_UNUSED(filterSettings)
     }
     QDir().mkpath(outDir);
-    const QStringList ids = { "rise-in", "typewriter", "fade-out",
-                              "wave", "breathe", "line-reveal" };
+    const QStringList ids = { "sharp-snap-rise", "tech-typewriter-std", "smooth-cinematic-fade",
+                              "loop-sine-wave", "loop-breathe-soft", "smooth-line-rise" };
     for (const auto& id : ids) {
         const auto preset = TextAnimPresets::byId(id);
         if (!preset) { continue; }

--- a/src/core/textanimpresets.h
+++ b/src/core/textanimpresets.h
@@ -37,11 +37,6 @@
 
 class TextBox;
 
-// how the sweep front travels across the text
-enum class TextAnimDirection : short {
-    leftToRight, rightToLeft
-};
-
 struct CORE_EXPORT TextAnimPreset {
     QString id;
     QString name;
@@ -51,6 +46,10 @@ struct CORE_EXPORT TextAnimPreset {
     bool byIndex = true;// stagger by fragment index (AE feel) instead of x position
     TextAnim::Kind kind = TextAnim::sweepIn;
 
+    // physical easing archetype (Back/Overshoot, Elastic, Bounce, Snap, Anticipate, Stepped, Smooth)
+    TextEasing easing = TextEasing::smooth;
+    qreal staggerPercent = 0.40; // fraction of total duration for staggering across fragments
+
     // transform "start state" applied at full influence
     // (influence animates from 1 -> 0 for entrances, so these describe
     // where the text comes FROM; loops oscillate around the rest state)
@@ -59,8 +58,11 @@ struct CORE_EXPORT TextAnimPreset {
     qreal rot = 0;      // degrees
     qreal scaleX = 1;
     qreal scaleY = 1;
+    qreal shearX = 0;
+    qreal shearY = 0;
     qreal opacity = 100;// %
     bool pivotCenter = false; // pivot near the fragment visual center
+    QString tag;        // e.g. "chars", "words", "lines", "stretch", "spin", "tech", "loop"
 
     // sweep timing / shape
     qreal duration = 1.0;     // seconds

--- a/src/core/texteffect.cpp
+++ b/src/core/texteffect.cpp
@@ -34,8 +34,83 @@
 #include "Animators/transformanimator.h"
 #include "MovablePoints/animatedpoint.h"
 #include "Expressions/expression.h"
+#include "ReadWrite/evformat.h"
+#include "ReadWrite/ereadstream.h"
+#include "ReadWrite/ewritestream.h"
+#include "XML/xevimporter.h"
+#include <cmath>
 
 namespace {
+static constexpr qreal kPi = 3.14159265358979323846;
+
+static qreal evaluateEasing(const TextEasing easing, const qreal t)
+{
+    if (t <= 0.0) { return 0.0; }
+    if (t >= 1.0) { return 1.0; }
+
+    switch (easing) {
+    case TextEasing::smooth:
+        // Quintic smootherstep: zero 1st & 2nd derivatives at both ends
+        return t * t * t * (t * (t * 6.0 - 15.0) + 10.0);
+
+    case TextEasing::sharpSnap: {
+        // High-velocity exponential ease-out (85% traveled in first 20% of duration)
+        const qreal val = 1.0 - std::pow(2.0, -10.0 * t);
+        const qreal norm = 1.0 - std::pow(2.0, -10.0);
+        return val / norm;
+    }
+
+    case TextEasing::overshoot: {
+        // Back-out overshoot (~12% rebound past rest target before settling)
+        const qreal c1 = 1.70158;
+        const qreal c3 = c1 + 1.0;
+        const qreal tm1 = t - 1.0;
+        return 1.0 + c3 * tm1 * tm1 * tm1 + c1 * tm1 * tm1;
+    }
+
+    case TextEasing::elastic: {
+        // Damped harmonic oscillator with 2 vibrant spring jelly cycles
+        const qreal c4 = (2.0 * kPi) / 3.0;
+        return std::pow(2.0, -10.0 * t) * std::sin((t * 10.0 - 0.75) * c4) + 1.0;
+    }
+
+    case TextEasing::bounce: {
+        // Multi-rebound gravitational bounce (3 bounces against rest floor)
+        const qreal n1 = 7.5625;
+        const qreal d1 = 2.75;
+        if (t < 1.0 / d1) {
+            return n1 * t * t;
+        } else if (t < 2.0 / d1) {
+            const qreal curT = t - (1.5 / d1);
+            return n1 * curT * curT + 0.75;
+        } else if (t < 2.5 / d1) {
+            const qreal curT = t - (2.25 / d1);
+            return n1 * curT * curT + 0.9375;
+        } else {
+            const qreal curT = t - (2.625 / d1);
+            return n1 * curT * curT + 0.984375;
+        }
+    }
+
+    case TextEasing::anticipate: {
+        // Anticipate (Back-In-Out): recoils -9% before launching with high velocity
+        const qreal c1 = 1.70158;
+        const qreal c2 = c1 * 1.525;
+        if (t < 0.5) {
+            return (std::pow(2.0 * t, 2) * ((c2 + 1.0) * 2.0 * t - c2)) / 2.0;
+        } else {
+            const qreal tm = 2.0 * t - 2.0;
+            return (std::pow(tm, 2) * ((c2 + 1.0) * tm + c2) + 2.0) / 2.0;
+        }
+    }
+
+    case TextEasing::stepped:
+        // Discrete 5-step quantized digital typewriter clock
+        return std::floor(t * 5.0) / 5.0;
+    }
+    return t;
+}
+
 // shared JS helpers for the preset-generated expressions
 const char* const kPresetDefs =
         "function pSat(t){return t<0?0:(t>1?1:t);}\n"
@@ -200,6 +275,62 @@ TextEffect::TextEffect() : eEffect("text effect") {
     prp_enabledDrawingOnCanvas();
 }
 
+void TextEffect::prp_writeProperty_impl(eWriteStream& dst) const
+{
+    eEffect::prp_writeProperty_impl(dst);
+    dst << mCustomPhysics;
+    if (mCustomPhysics) {
+        dst << static_cast<int>(mEasing);
+        dst << mStartFrame;
+        dst << mDurFrames;
+        dst << static_cast<int>(mDirection);
+        dst << static_cast<int>(mKind);
+        dst << mStaggerPercent;
+    }
+}
+
+void TextEffect::prp_readProperty_impl(eReadStream& src)
+{
+    eEffect::prp_readProperty_impl(src);
+    if (src.evFileVersion() >= EvFormat::textPhysicsEasing) {
+        src >> mCustomPhysics;
+        if (mCustomPhysics) {
+            int easingVal = 0, dirVal = 0, kindVal = 0;
+            src >> easingVal >> mStartFrame >> mDurFrames >> dirVal >> kindVal >> mStaggerPercent;
+            mEasing = static_cast<TextEasing>(easingVal);
+            mDirection = static_cast<TextAnimDirection>(dirVal);
+            mKind = static_cast<TextAnim::Kind>(kindVal);
+        }
+    }
+}
+
+void TextEffect::writeIdentifierXEV(QDomElement& ele) const
+{
+    if (mCustomPhysics) {
+        ele.setAttribute(QStringLiteral("customPhysics"), 1);
+        ele.setAttribute(QStringLiteral("easing"), static_cast<int>(mEasing));
+        ele.setAttribute(QStringLiteral("startFrame"), mStartFrame);
+        ele.setAttribute(QStringLiteral("durFrames"), mDurFrames);
+        ele.setAttribute(QStringLiteral("direction"), static_cast<int>(mDirection));
+        ele.setAttribute(QStringLiteral("kind"), static_cast<int>(mKind));
+        ele.setAttribute(QStringLiteral("staggerPercent"), mStaggerPercent);
+    }
+}
+
+void TextEffect::prp_readPropertyXEV_impl(const QDomElement& ele, const XevImporter& imp)
+{
+    eEffect::prp_readPropertyXEV_impl(ele, imp);
+    if (ele.hasAttribute(QStringLiteral("customPhysics"))) {
+        mCustomPhysics = ele.attribute(QStringLiteral("customPhysics")).toInt() != 0;
+        mEasing = static_cast<TextEasing>(ele.attribute(QStringLiteral("easing")).toInt());
+        mStartFrame = ele.attribute(QStringLiteral("startFrame")).toInt();
+        mDurFrames = ele.attribute(QStringLiteral("durFrames")).toInt();
+        mDirection = static_cast<TextAnimDirection>(ele.attribute(QStringLiteral("direction")).toInt());
+        mKind = static_cast<TextAnim::Kind>(ele.attribute(QStringLiteral("kind")).toInt());
+        mStaggerPercent = ele.attribute(QStringLiteral("staggerPercent"), QStringLiteral("0.4")).toDouble();
+    }
+}
+
 bool ptXLess(const QPointF& p1, const QPointF& p2)
 { return p1.x() < p2.x(); }
 
@@ -350,8 +481,11 @@ QMatrix TextEffect::getTransform(const qreal relFrame,
     const auto posAnim = mTransform->getPosAnimator();
     const auto rotAnim = mTransform->getRotAnimator();
     const auto scaleAnim = mTransform->getScaleAnimator();
+    const auto shearAnim = mTransform->getShearAnimator();
     const qreal xScale = scaleAnim->getEffectiveXValue(relFrame);
     const qreal yScale = scaleAnim->getEffectiveYValue(relFrame);
+    const qreal shx = shearAnim ? shearAnim->getEffectiveXValue(relFrame) : 0.0;
+    const qreal shy = shearAnim ? shearAnim->getEffectiveYValue(relFrame) : 0.0;
     const qreal xPivot = pivotAnim->getEffectiveXValue(relFrame) + addPivot.x();
     const qreal yPivot = pivotAnim->getEffectiveYValue(relFrame) + addPivot.y();
     QMatrix transform;
@@ -360,6 +494,9 @@ QMatrix TextEffect::getTransform(const qreal relFrame,
     transform.rotate(rotAnim->getEffectiveValue(relFrame)*influence);
     transform.scale(1 - influence + xScale*influence,
                     1 - influence + yScale*influence);
+    if(!isZero4Dec(shx) || !isZero4Dec(shy)) {
+        transform.shear(shx * influence, shy * influence);
+    }
     transform.translate(-xPivot, -yPivot);
     return transform;
 }
@@ -369,7 +506,7 @@ void TextEffect::applyToLetter(LetterRenderData * const letterData,
     const qreal relFrame = letterData->fRelFrame;
     if(!isZero4Dec(influence)) {
         const qreal currOpacity = mTransform->getOpacity(relFrame)*0.01;
-        const qreal opacity = 1 + influence*(currOpacity - 1);
+        const qreal opacity = qBound(0.0, 1.0 + influence*(currOpacity - 1.0), 1.0);
 
         const auto transform = getTransform(relFrame, influence,
                                             letterData->fLetterPos);
@@ -390,7 +527,7 @@ void TextEffect::applyToWord(WordRenderData * const wordData,
     const qreal relFrame = wordData->fRelFrame;
     if(!isZero4Dec(influence)) {
         const qreal currOpacity = mTransform->getOpacity(relFrame)*0.01;
-        const qreal opacity = 1 + influence*(currOpacity - 1);
+        const qreal opacity = qBound(0.0, 1.0 + influence*(currOpacity - 1.0), 1.0);
 
         const auto transform = getTransform(relFrame, influence,
                                             wordData->fWordPos);
@@ -406,7 +543,7 @@ void TextEffect::applyToLine(LineRenderData * const lineData,
     const qreal relFrame = lineData->fRelFrame;
     if(!isZero4Dec(influence)) {
         const qreal currOpacity = mTransform->getOpacity(relFrame)*0.01;
-        const qreal opacity = 1 + influence*(currOpacity - 1);
+        const qreal opacity = qBound(0.0, 1.0 + influence*(currOpacity - 1.0), 1.0);
 
         const auto transform = getTransform(relFrame, influence,
                                             lineData->fLinePos);
@@ -472,6 +609,116 @@ void TextEffect::apply(TextBoxRenderData * const textData) const {
     const qreal relFrame = textData->fRelFrame;
     const qreal maxInfl = mInfluence->getEffectiveValue(relFrame);
     if(isZero4Dec(maxInfl)) return;
+
+    if (mCustomPhysics && (mKind == TextAnim::sweepIn || mKind == TextAnim::sweepOut)) {
+        const auto computePhysicsInfl = [this, relFrame, maxInfl](const qreal uRaw) -> qreal {
+            const qreal u = (mDirection == TextAnimDirection::rightToLeft) ? (1.0 - uRaw) : uRaw;
+            const qreal D = qMax(1.0, static_cast<qreal>(mDurFrames));
+            const qreal S = qBound(0.05, mStaggerPercent, 0.85);
+            const qreal tStagger = S * D;
+            const qreal tFrag = qMax(1.0, D - tStagger);
+            const qreal fStart = static_cast<qreal>(mStartFrame) + u * tStagger;
+            const qreal deltaF = relFrame - fStart;
+
+            qreal tau = 0.0;
+            if (deltaF <= 0.0) {
+                tau = 0.0;
+            } else if (deltaF >= tFrag) {
+                tau = 1.0;
+            } else {
+                tau = deltaF / tFrag;
+            }
+
+            const qreal e = evaluateEasing(mEasing, tau);
+            const qreal rawInfl = (mKind == TextAnim::sweepIn) ? (1.0 - e) : e;
+            return rawInfl * maxInfl;
+        };
+
+        const bool byIndex = mStaggerBy->getCurrentValue() == 1;
+
+        switch(target()) {
+        case TextFragmentType::letter: {
+            int nFragments = 0;
+            qreal minX = 1e9, maxX = -1e9;
+            for (const auto& line : textData->fLines) {
+                for (const auto& word : line->fWords) {
+                    for (const auto& letter : word->fLetters) {
+                        nFragments++;
+                        const qreal lx = letter->fOriginalPos.x();
+                        if (lx < minX) minX = lx;
+                        if (lx > maxX) maxX = lx;
+                    }
+                }
+            }
+            if (nFragments == 0) break;
+            const qreal spanX = (maxX > minX) ? (maxX - minX) : 1.0;
+
+            int iFragments = 0;
+            for (const auto& line : textData->fLines) {
+                for (const auto& word : line->fWords) {
+                    for (const auto& letter : word->fLetters) {
+                        const qreal u = byIndex ?
+                            (nFragments > 1 ? static_cast<qreal>(iFragments) / (nFragments - 1) : 0.0) :
+                            qBound(0.0, (letter->fOriginalPos.x() - minX) / spanX, 1.0);
+                        iFragments++;
+                        const qreal influence = computePhysicsInfl(u);
+                        applyToLetter(letter.get(), influence);
+                    }
+                }
+            }
+        } break;
+        case TextFragmentType::word: {
+            int nFragments = 0;
+            qreal minX = 1e9, maxX = -1e9;
+            for (const auto& line : textData->fLines) {
+                for (const auto& word : line->fWords) {
+                    nFragments++;
+                    const qreal wx = word->fOriginalPos.x();
+                    if (wx < minX) minX = wx;
+                    if (wx > maxX) maxX = wx;
+                }
+            }
+            if (nFragments == 0) break;
+            const qreal spanX = (maxX > minX) ? (maxX - minX) : 1.0;
+
+            int iFragments = 0;
+            for (const auto& line : textData->fLines) {
+                for (const auto& word : line->fWords) {
+                    const qreal u = byIndex ?
+                        (nFragments > 1 ? static_cast<qreal>(iFragments) / (nFragments - 1) : 0.0) :
+                        qBound(0.0, (word->fOriginalPos.x() - minX) / spanX, 1.0);
+                    iFragments++;
+                    const qreal influence = computePhysicsInfl(u);
+                    applyToWord(word.get(), influence);
+                }
+            }
+        } break;
+        case TextFragmentType::line: {
+            const int nFragments = textData->fLines.count();
+            if (nFragments == 0) break;
+            qreal minY = 1e9, maxY = -1e9;
+            for (const auto& line : textData->fLines) {
+                const qreal ly = line->fOriginalPos.y();
+                if (ly < minY) minY = ly;
+                if (ly > maxY) maxY = ly;
+            }
+            const qreal spanY = (maxY > minY) ? (maxY - minY) : 1.0;
+
+            int iFragments = 0;
+            for (const auto& line : textData->fLines) {
+                const qreal u = byIndex ?
+                    (nFragments > 1 ? static_cast<qreal>(iFragments) / (nFragments - 1) : 0.0) :
+                    qBound(0.0, (line->fOriginalPos.y() - minY) / spanY, 1.0);
+                iFragments++;
+                const qreal influence = computePhysicsInfl(u);
+                applyToLine(line.get(), influence);
+            }
+        } break;
+        default: break;
+        }
+        return;
+    }
+
     const qreal minInfl = mMinInfluence->getEffectiveValue(relFrame);
     const qreal ampl = mInfluence->getEffectiveValue(relFrame);
     const qreal period = mPeriod->getEffectiveValue(relFrame);
@@ -588,6 +835,7 @@ void TextEffect::setupFromPreset(const TextAnimPreset &preset,
     mTransform->setPosition(preset.posX, preset.posY);
     mTransform->setRotation(preset.rot);
     mTransform->setScale(preset.scaleX, preset.scaleY);
+    mTransform->setShear(preset.shearX, preset.shearY);
     mTransform->setOpacity(preset.opacity);
     if(preset.pivotCenter) {
         mTransform->setPivot(0.3*fontSize, -0.35*fontSize);
@@ -599,6 +847,15 @@ void TextEffect::setupFromPreset(const TextAnimPreset &preset,
     const int durF = qMax(1, qRound(preset.duration*durationScale*fps));
     const int F0 = startFrame;
     const int F1 = F0 + durF;
+
+    mCustomPhysics = (preset.kind == TextAnim::sweepIn || preset.kind == TextAnim::sweepOut);
+    mEasing = preset.easing;
+    mStartFrame = startFrame;
+    mDurFrames = durF;
+    mDirection = preset.direction;
+    mKind = preset.kind;
+    mStaggerPercent = preset.staggerPercent;
+
     const qreal soft = qBound(0.02*W, preset.softness*W, 0.9*W);
     const qreal left = -0.15*W;
     const qreal right = 1.15*W;

--- a/src/core/texteffect.h
+++ b/src/core/texteffect.h
@@ -37,8 +37,26 @@ class WordRenderData;
 class LineRenderData;
 class TextBoxRenderData;
 class AnimatedPoint;
+class XevImporter;
 
 enum class TextFragmentType : short;
+
+// Physical easing archetype applied to fragment entrance / exit
+enum class TextEasing : short {
+    smooth = 0,
+    sharpSnap,
+    overshoot,
+    elastic,
+    bounce,
+    anticipate,
+    stepped
+};
+
+// Direction along text fragments
+enum class TextAnimDirection : short {
+    leftToRight,
+    rightToLeft
+};
 
 // recipe describing a baked text animation (see textanimpresets.h)
 struct TextAnimPreset;
@@ -52,24 +70,30 @@ class CORE_EXPORT TextEffect : public eEffect {
 public:
     TextEffect();
 
-    bool SWT_dropSupport(const QMimeData * const data);
-    bool SWT_drop(const QMimeData * const data);
-    QMimeData *SWT_createMimeData();
+    bool SWT_dropSupport(const QMimeData * const data) override;
+    bool SWT_drop(const QMimeData * const data) override;
+    QMimeData *SWT_createMimeData() override;
 
-    void prp_setupTreeViewMenu(PropertyMenu * const menu);
+    void prp_setupTreeViewMenu(PropertyMenu * const menu) override;
     void prp_drawCanvasControls(SkCanvas * const canvas,
                                 const CanvasMode mode,
                                 const float invScale,
-                                const bool ctrlPressed);
+                                const bool ctrlPressed) override;
 
-    void writeIdentifier(eWriteStream& dst) const
+    void writeIdentifier(eWriteStream& dst) const override
     { Q_UNUSED(dst) }
 
-    void writeIdentifierXEV(QDomElement& ele) const
-    { Q_UNUSED(ele) }
+    void writeIdentifierXEV(QDomElement& ele) const override;
+    void prp_writeProperty_impl(eWriteStream& dst) const override;
+    void prp_readProperty_impl(eReadStream& src) override;
+    void prp_readPropertyXEV_impl(const QDomElement& ele, const XevImporter& imp) override;
 
     void apply(TextBoxRenderData * const textData) const;
     TextFragmentType target() const;
+
+    bool hasCustomPhysics() const { return mCustomPhysics; }
+    TextEasing getEasing() const { return mEasing; }
+    void setEasing(const TextEasing easing) { mEasing = easing; }
 
     // configures this effect from an animation preset recipe
     // (fragment type, stagger mode, transform start state and the
@@ -131,6 +155,15 @@ private:
     qsptr<PathEffectCollection> mOutlinePathEffects;
 
     qsptr<RasterEffectCollection> mRasterEffects;
+
+    // Per-fragment physical easing animation parameters
+    bool mCustomPhysics = false;
+    TextEasing mEasing = TextEasing::smooth;
+    int mStartFrame = 0;
+    int mDurFrames = 24;
+    TextAnimDirection mDirection = TextAnimDirection::leftToRight;
+    TextAnim::Kind mKind = TextAnim::sweepIn;
+    qreal mStaggerPercent = 0.40;
 };
 
 #endif // TEXTEFFECT_H


### PR DESCRIPTION
## 概述

本 PR 深度扩充了 Friction 2.5D 的文字与图层动力学动画预设库至 230 种，并彻底重构了预设面板（Text & Layer Animation Presets）的 UI 视觉与交互层级，提供开箱即用的专业动效制作体验

### 主要改动

1. 预设库深度扩充（230 种全原生集成）
- 文字动画预设（168 种）：新增 63 种高质感字符动效，涵盖锐利弹性、丝滑流体、通道分离、3D空间矩阵、极客解密与多形态循环动效
- 通用图层预设（62 种）：新增 30 种图层运动图形动力学脚本，包含 2.5D 空间折叠翻门、空间下潜、物理果冻抖动、重力下坠震颤、磁吸卡位、抽屉拉伸与心跳脉冲

2. 预设面板 UI 视觉与交互重构
- 三段式独立卡片布局：将顶部动效预览画面与操作按键彻底解耦，预览区 100% 独立无遮挡；中部展示粗体名称与语义化属性徽章（如逐字、图层、3D空间、循环动效）；底部独立排布入/全/出操作按钮
- 单级流式分类导航：移除重叠冲突的折叠手风琴结构，改为顶部单级标签栏带实时数量角标（全部 230、锐利 40、丝滑 32、通道 35、3D空间 25、极客 18、图层 52、循环 28），支持单次点击直接筛选与实时流式重排
- 紧凑型双行底部控制栏：第一行排布时长缩放（50%-300%）、数值微调、重置按钮与视图缩放滑块；第二行排布呼吸状态指示灯与莫兰迪柔和清空预设按钮，在窄侧边栏坞下不挤压换行

3. 质量保障与自动化测试
- 单元测试（Test 8）补充新增文字与图层预设注册表完整性与脚本生成校验
- 全量单元测试 11/11 全部通过，编译无警告